### PR TITLE
Add proper docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: "3.8"
+services:
+  lavalink:
+    container_name: lavamusic-lavalink
+    image: fredboat/lavalink:dev
+    environment:
+      SERVER_PORT: 2333
+      SERVER_ADDRESS: 0.0.0.0
+      LAVALINK_SERVER_PASSWORD: "youshallnotpass"
+      LAVALINK_SERVER_SOURCES_YOUTUBE: 'true'
+      LAVALINK_SERVER_SOURCES_BANDCAMP: 'true'
+      LAVALINK_SERVER_SOURCES_SOUNDCLOUD: 'true'
+      LAVALINK_SERVER_SOURCES_TWITCH: 'true'
+      LAVALINK_SERVER_SOURCES_VIMEO: 'true'
+      LAVALINK_SERVER_SOURCES_HTTP: 'true'
+      LAVALINK_SERVER_SOURCES_LOCAL: 'false'
+      LAVALINK_SERVER_BUFFER_DURATION_MS: 400
+      LAVALINK_SERVER_FRAME_BUFFER_DURATIONS_MS: 5000
+      LAVALINK_SERVER_TRACK_STRUCK_THRESHOLD_MS: 10000
+      LAVALINK_SERVER_YOUTUBE_PLAYLIST_LOAD_LIMIT: 6
+      LAVALINK_SERVER_PLAYER_UPDATE_INTERVAL: 5
+      LAVALINK_SERVER_YOUTUBE_SEARCH_ENABLED: 'true'
+      LAVALINK_SERVER_SOUNDCLOUD_SEARCH_ENABLED: 'true'
+      #LAVALINK_SERVER_YOUTUBE_CONFIG_EMAIL:
+      #LAVALINK_SERVER_YOUTUBE_CONFIG_PASSWORD:
+      LAVALINK_SERVER_SENTRY_DSN: ""
+    restart: on-failure
+    
+  lavamusic:
+    container_name: lavamusic
+    image: ghcr.io/brblacky/lavamusic:latest
+    environment:
+      TOKEN: "put your bot token"
+      PREFIX: "your bot prefix"
+      OWNERID: "your discord id"
+      SPOTIFYID: "Spotify client id"
+      SPOTIFYSECRET: "Spotify client secret "
+      MONGO_URI: "mongodb://mongoadmin:mongopassword@db:27017"
+      COlOR: "embed colour"
+      LOGS: "logs channel id"
+      IMG: "setup system background image "
+      SUPPORT: "support server invite link"
+      INVITE: "bot invite link"
+      NODE_HOST: "lavalink"
+      NODE_ID: "lavamusic-lavalink"
+      NODE_PORT: "2333"
+      NODE_PASSWORD: "youshallnotpass"
+      NODE_SECURE: "false"
+    restart: on-failure
+    depends_on:
+      - lavalink
+      - mongodb
+    links:
+      - mongodb:db
+      - lavalink
+
+  mongodb:
+    container_name: lavamusic-mongodb
+    image: mongo:latest
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: mongoadmin
+      MONGO_INITDB_ROOT_PASSWORD: mongopassword
+    restart: on-failure
+    volumes:
+      - mongodb_data:/data/db
+
+volumes:
+  mongodb_data:
+
+networks:
+  default:
+    name: net-lavamusic


### PR DESCRIPTION
This commit adds a more defined docker-compose then: https://github.com/avaire/avaire/blob/master/docker-compose.yml

By using env variables in a more proper way (dont copy the .env/yaml file), it'll be as easy to edit these as the user can go into the docker-compose and edit them like so.

We could also use the .env but then ya would need to ask people to fill in the .env (i can't specify the vars into the docker-compose b/c they get overridden (b/c we do have to add comments so people know what to enter).
Source: https://docs.docker.com/compose/environment-variables/#set-environment-variables-with-docker-compose-run

I urge you to try and test it yourself. You only have to get docker-compose and the file. Then after filling out docker-compose.yml and doing: docker-compose up (-d). It shall fetch the db, lavalink and lavamusic and it shall mount the database internally.

Recreating will keep the bot's data in the database persistant.

If you have any questions, please feel free to tell them, after ya ok with these changes i'll edit the readme to include insructions.

oh, almost forgot! We can include watchtower to auto-update and restart these containers. We can configure it a bit for the end user to not immediatly restart after ya brough an update. But it's up to you if you want me to include that.
See: https://containrrr.dev/watchtower/arguments/ & https://containrrr.dev/watchtower/usage-overview/ for more info.

Looking forward to your reply. Macley#6969

Signed-off-by: Macley <26381427+Macleykun@users.noreply.github.com>