### PR TITLE
Fix config slashcommands permission issue

### DIFF
--- a/src/events/Client/interactionCreate.js
+++ b/src/events/Client/interactionCreate.js
@@ -2,6 +2,7 @@ const {
   CommandInteraction,
   InteractionType,
   PermissionFlagsBits,
+  PermissionsBitField,
   EmbedBuilder,
 } = require("discord.js");
 const { SearchResult, Track } = require("erela.js");

--- a/src/slashCommands/Config/adddj.js
+++ b/src/slashCommands/Config/adddj.js
@@ -10,7 +10,7 @@ const db = require("../../schema/dj");
 module.exports = {
   name: "adddj",
   description: "Sets the DJ role.",
-  userPrems: ["MangeGuild"],
+  userPrems: ["ManageGuild"],
   options: [
     {
       name: "dj",

--- a/src/slashCommands/Config/removedj.js
+++ b/src/slashCommands/Config/removedj.js
@@ -5,7 +5,7 @@ const db = require("../../schema/dj");
 module.exports = {
   name: "removedj",
   description: "Removes the DJ role.",
-  userPrems: ["MangeGuild"],
+  userPrems: ["ManageGuild"],
   owner: false,
 
   /**

--- a/src/slashCommands/Config/setprefix.js
+++ b/src/slashCommands/Config/setprefix.js
@@ -9,7 +9,7 @@ const MusicBot = require("../../structures/Client.js");
 module.exports = {
   name: "setprefix",
   description: "Sets a custom prefix.",
-  userPrems: ["MangeGuild"],
+  userPrems: ["ManageGuild"],
   default_member_permissions: ["ManageGuild"],
   options: [
     {

--- a/src/slashCommands/Config/toggledj.js
+++ b/src/slashCommands/Config/toggledj.js
@@ -4,7 +4,7 @@ const db = require("../../schema/dj");
 module.exports = {
   name: "toggledj",
   description: "Toggles DJ mode.",
-  userPrems: ["MangeGuild"],
+  userPrems: ["ManageGuild"],
   owner: false,
 
   run: async (client, interaction) => {


### PR DESCRIPTION
A Typo in the code doesn't let the bot check for a member's permission and as a result, they were able to run configs without having permissions normally.

### So let me explain:
- InteractionCreate.js didn't have `PermissionsBitField` defined but it's required for the `/adddj` `/removedj` `/toggledj` etc. to work
- Since `Adddj.js` `Removedj.js` and `Toggledj.js` were messed up, normal members still were able to use these commands.
- The reason is `userPrems: ["MangeGuild"],`, which is a wrong word.
- `userPrems: ["ManageGuild"],` fixes the issue completely.

This is a small fix but the permission check now works as intended. 
It doesn't show up anymore for you if you don't have permission to use it

### Images:
Before:
https://cdn.discordapp.com/attachments/689085528687247433/1023523518807277568/unknown.png

After:
https://cdn.discordapp.com/attachments/689085528687247433/1023523735854125116/unknown.png