### PR TITLE
Added Filter/Rate command, Filter Amount optional param, Seeking to HH:mm:ss

### DIFF
--- a/src/commands/Music/filters.js
+++ b/src/commands/Music/filters.js
@@ -30,7 +30,7 @@ module.exports = {
         const but = new ButtonBuilder().setCustomId("clear_but").setLabel("Clear").setStyle(ButtonStyle.Danger);
         const but2 = new ButtonBuilder().setCustomId("bass_but").setLabel("Bass").setStyle(ButtonStyle.Primary);
         const but3 = new ButtonBuilder().setCustomId("night_but").setLabel("Nightcore").setStyle(ButtonStyle.Primary);
-        const but4 = new ButtonBuilder().setCustomId("picth_but").setLabel("Pitch").setStyle(ButtonStyle.Primary);
+        const but4 = new ButtonBuilder().setCustomId("pitch_but").setLabel("Pitch").setStyle(ButtonStyle.Primary);
         const but5 = new ButtonBuilder().setCustomId("distort_but").setLabel("Distort").setStyle(ButtonStyle.Primary);
         const but6 = new ButtonBuilder().setCustomId("eq_but").setLabel("Equalizer").setStyle(ButtonStyle.Primary);
         const but7 = new ButtonBuilder().setCustomId("8d_but").setLabel("8D").setStyle(ButtonStyle.Primary);
@@ -67,7 +67,7 @@ module.exports = {
                 await player.setNightcore(true);
                 if (m) await m.edit({ embeds: [embed], components: [row, row2] });
                 return await b.editReply({ embeds: [embed1.setDescription(`${emojiequalizer} Nightcore mode is ON`)] });
-            } else if (b.customId === "picth_but") {
+            } else if (b.customId === "pitch_but") {
                 await player.setPitch(2);
                 if (m) await m.edit({ embeds: [embed], components: [row, row2] });
                 return await b.editReply({ embeds: [embed1.setDescription(`${emojiequalizer} Pitch mode is ON`)] });

--- a/src/commands/Music/seek.js
+++ b/src/commands/Music/seek.js
@@ -2,13 +2,24 @@ const { EmbedBuilder } = require("discord.js");
 const { convertTime } = require('../../utils/convert.js')
 const ms = require('ms');
 
+function hmsToMiliseconds(str) {
+    var p = str.split(':'),
+        s = 0, m = 1;
+
+    while (p.length > 0) {
+        s += m * parseInt(p.pop(), 10);
+        m *= 60;
+    }
+    return s*1000;
+}
+
 module.exports = {
   	name: "seek",
   	aliases: [],
   	category: "Music",
   	description: "Seek the currently playing song.",
-  	args: true,
-    usage: "<10s || 10m || 10h>",
+    args: false,
+    usage: "<10s || 10m || 10h || HH:mm:ss || mm:ss>",
     userPerms: [],
     dj: true,
     owner: false,
@@ -26,7 +37,8 @@ module.exports = {
             return message.reply({embeds: [thing]});
         }
 
-        const time = ms(args[0])
+        let time = interaction.options.getString("time");
+        time.includes(":") || Number.isInteger(time) ? time = hmsToMiliseconds(time) : time = ms(time);
         const position = player.position;
         const duration = player.queue.current.duration;
 
@@ -54,7 +66,7 @@ module.exports = {
         } else {
             let thing = new EmbedBuilder()
                 .setColor("Red")
-                .setDescription(`Seek duration exceeds song duration.\nSong duration: \`${convertTime(duration)}\``);
+                .setDescription(`Seek duration exceeds song duration.\nRequested: \`${convertTime(time)}\`\nSong duration: \`${convertTime(duration)}\``);
             return message.reply({embeds: [thing]});
         }
 	

--- a/src/slashCommands/Music/filters.js
+++ b/src/slashCommands/Music/filters.js
@@ -66,7 +66,7 @@ module.exports = {
             description: "Specify the filter's value",
             type: ApplicationCommandOptionType.Number,
             min_value: 0.05,
-            max_value: 8.0
+            max_value: 5.0
         }
     ],
 
@@ -119,7 +119,7 @@ module.exports = {
                 break;
             case 'pitch':
                 player.setPitch(amount);
-                thing.setDescription(`${emojiequalizer} Pitch shift has been SET (${amount}×)`);
+                thing.setDescription(`${emojiequalizer} Pitch shift has been SET (${player.getPitch()}×)`);
                 break;
             case 'distort':
                 player.setDistortion(true);
@@ -135,11 +135,11 @@ module.exports = {
                 break;
             case 'speed':
                 player.setSpeed(amount);
-                thing.setDescription(`${emojiequalizer} Tempo has been SET (${amount}×)`);
+                thing.setDescription(`${emojiequalizer} Tempo has been SET (${player.getSpeed()}×)`);
                 break;
             case 'rate':
                 player.setRate(amount);
-                thing.setDescription(`${emojiequalizer} Rate has been SET (${amount}×)`);
+                thing.setDescription(`${emojiequalizer} Rate has been SET (${player.getRate()}×)`);
                 break;
             case '8d':
                 player.set8D(true);

--- a/src/slashCommands/Music/filters.js
+++ b/src/slashCommands/Music/filters.js
@@ -21,7 +21,7 @@ module.exports = {
                 },
                 {
                     name: "Bass",
-                    value: "bass",
+                    value: "bass"
                 },
                 {
                     name: "Nightcore",
@@ -52,10 +52,21 @@ module.exports = {
                     value: "speed"
                 },
                 {
+                    name: "Speed (w/o pitch correction)",
+                    value: "rate"
+                },
+                {
                     name: "Vaporwave",
                     value: "vapo"
                 }
             ]
+        },
+        {
+            name: "amount",
+            description: "Specify the filter's value",
+            type: ApplicationCommandOptionType.Number,
+            min_value: 0.05,
+            max_value: 8.0
         }
     ],
 
@@ -70,6 +81,8 @@ module.exports = {
             ephemeral: false
         });
         const filter = interaction.options.getString("filter");
+        let amount = interaction.options.getNumber("amount")
+        if(typeof amount === 'undefined' || amount === null) amount = 2; // default value
 
         const player = interaction.client.manager.get(interaction.guildId);
         if (!player.queue.current) {
@@ -87,46 +100,50 @@ module.exports = {
 
             case 'bass':
                 player.setBassboost(true);
-                thing.setDescription(`${emojiequalizer} Bass mode is ON`);
+                thing.setDescription(`${emojiequalizer} Bass EQ preset has been turned ON`);
                 break;
             case 'eq':
                 player.setEqualizer(true);
-                thing.setDescription(`${emojiequalizer} Trablebass mode is ON`);
+                thing.setDescription(`${emojiequalizer} Equalizer has been turned ON`);
                 break;
             case 'bassboost':
                 var bands = new Array(7).fill(null).map((_, i) => (
                     { band: i, gain: 0.25 }
                 ));
                 player.setEQ(...bands);
-                thing.setDescription(`${emojiequalizer} Bass Boost mode is ON`);
+                thing.setDescription(`${emojiequalizer} Bass Boost (custom EQ) has been turned ON`);
                 break;
             case 'night':
                 player.setNightcore(true);
-                thing.setDescription(`${emojiequalizer} Nightcore Equalizer mode is ON`);
+                thing.setDescription(`${emojiequalizer} Nightcore EQ preset has been turned ON`);
                 break;
             case 'pitch':
-                player.setPitch(2);
-                thing.setDescription(`${emojiequalizer} Pitch Equalizer mode is ON`);
+                player.setPitch(amount);
+                thing.setDescription(`${emojiequalizer} Pitch shift has been SET (${amount}×)`);
                 break;
             case 'distort':
                 player.setDistortion(true);
-                thing.setDescription(`${emojiequalizer} Distort Equalizer mode is ON`);
+                thing.setDescription(`${emojiequalizer} Distortion EQ preset has been turned ON`);
                 break;
             case 'vapo':
                 player.setVaporwave(true);
-                thing.setDescription(`${emojiequalizer} Vaporwave Equalizer mode is ON`);
+                thing.setDescription(`${emojiequalizer} Vaporwave EQ preset has been turned ON`);
                 break;
             case 'clear':
                 player.clearEffects();
-                thing.setDescription(`${emojiequalizer} Equalizer mode is OFF`);
+                thing.setDescription(`${emojiequalizer} Equalizer has been turned OFF`);
                 break;
             case 'speed':
-                player.setSpeed(2);
-                thing.setDescription(`${emojiequalizer} Speed mode is ON`);
+                player.setSpeed(amount);
+                thing.setDescription(`${emojiequalizer} Tempo has been SET (${amount}×)`);
+                break;
+            case 'rate':
+                player.setRate(amount);
+                thing.setDescription(`${emojiequalizer} Rate has been SET (${amount}×)`);
                 break;
             case '8d':
                 player.set8D(true);
-                thing.setDescription(`${emojiequalizer} 8D mode is ON`);
+                thing.setDescription(`${emojiequalizer} 8D mode has been turned ON`);
         }
         return interaction.editReply({ embeds: [thing] });
     }

--- a/src/slashCommands/Music/filters.js
+++ b/src/slashCommands/Music/filters.js
@@ -81,7 +81,7 @@ module.exports = {
             ephemeral: false
         });
         const filter = interaction.options.getString("filter");
-        let amount = interaction.options.getNumber("amount")
+        let amount = interaction.options.getNumber("amount");
         if(typeof amount === 'undefined' || amount === null) amount = 2; // default value
 
         const player = interaction.client.manager.get(interaction.guildId);

--- a/src/structures/Lavamusic.js
+++ b/src/structures/Lavamusic.js
@@ -37,6 +37,17 @@ Structure.extend(
         }
         return (this.nowPlayingMessage = message);
       }
+
+      getSpeed() {
+        return this.speed;
+      }
+      getPitch() {
+        return this.pitch;
+      }
+      getRate() {
+        return this.rate;
+      }
+
       set8D(value) {
         if (typeof value !== "boolean") {
           throw new RangeError(
@@ -67,6 +78,7 @@ Structure.extend(
 
         return this;
       }
+
       setSpeed(speed) {
         if (isNaN(speed)) {
           throw new RangeError("Player#setSpeed() Speed must be a number.");
@@ -75,6 +87,7 @@ Structure.extend(
         this.setTimescale(speed);
         return this;
       }
+
       setPitch(pitch) {
         if (isNaN(pitch)) {
           throw new RangeError("Player#setPitch() Pitch must be a number.");
@@ -83,6 +96,7 @@ Structure.extend(
         this.setTimescale(this.speed, pitch);
         return this;
       }
+
       setRate(rate) {
         if (isNaN(rate)) {
           throw new RangeError("Player#setRate() Rate must be a number.");
@@ -91,7 +105,6 @@ Structure.extend(
         this.setTimescale(this.speed, this.pitch, rate);
         return this;
       }
-      
 
       setNightcore(nighcore) {
         if (typeof nighcore !== "boolean") {
@@ -114,6 +127,7 @@ Structure.extend(
         }
         return this;
       }
+
       setVaporwave(vaporwave) {
         if (typeof vaporwave !== "boolean") {
           throw new RangeError(
@@ -135,6 +149,7 @@ Structure.extend(
         }
         return this;
       }
+
       setDistortion(distortion) {
         if (typeof distortion !== "boolean") {
           throw new RangeError(
@@ -156,6 +171,7 @@ Structure.extend(
         }
         return this;
       }
+
       setBassboost(bassboost) {
         if (typeof bassboost !== "boolean") {
           throw new RangeError(

--- a/src/structures/Lavamusic.js
+++ b/src/structures/Lavamusic.js
@@ -83,6 +83,15 @@ Structure.extend(
         this.setTimescale(this.speed, pitch);
         return this;
       }
+      setRate(rate) {
+        if (isNaN(rate)) {
+          throw new RangeError("Player#setRate() Rate must be a number.");
+        }
+        this.rate = Math.max(Math.min(rate, 5), 0.05);
+        this.setTimescale(this.speed, this.pitch, rate);
+        return this;
+      }
+      
 
       setNightcore(nighcore) {
         if (typeof nighcore !== "boolean") {


### PR DESCRIPTION
In current state, Pitch and Speed filters are hardcoded to increase the pitch/speed by two times (2x multiplier).
To allow slow playback, an optional `amount` parameter has been added to the Slash commands. Default value remains (`2x`).
Furthermore, a new Rate command has been added (i.e. Speed command, but without audio pitch correction).
Finally, Seek command can now parse both `HH:mm:ss` and `mm:ss` time formats in addition to simple parsing by `ms("10s")`.