### PR TITLE
Seek: Allow more characters as unit separator

### DIFF
--- a/src/commands/Music/seek.js
+++ b/src/commands/Music/seek.js
@@ -8,7 +8,7 @@ module.exports = {
   	category: "Music",
   	description: "Seek the currently playing song.",
     args: false,
-    usage: "<10s || 10m || 10h || HH:mm:ss || mm:ss>",
+    usage: "<10s || 10m || 10h || HH:mm:ss || mm:ss || mm ss>",
     userPerms: [],
     dj: true,
     owner: false,
@@ -27,7 +27,7 @@ module.exports = {
         }
 
         let time = args[0];
-        time.includes(":") || Number.isInteger(time) ? time = convertHmsToMs(time) : time = ms(time);
+        /^[0-9 :.-]+$/.test(time) ? time = convertHmsToMs(time) : time = ms(time);
         const position = player.position;
         const duration = player.queue.current.duration;
 

--- a/src/slashCommands/Music/seek.js
+++ b/src/slashCommands/Music/seek.js
@@ -13,7 +13,7 @@ module.exports = {
     options: [
         {
             name: "time",
-            description: "<10s || 10m || 10h || HH:mm:ss || mm:ss>",
+            description: "<10s || 10m || 10h || HH:mm:ss || mm:ss || mm ss>",
             required: true,
             type: ApplicationCommandOptionType.String
         }
@@ -39,7 +39,7 @@ module.exports = {
         }
 
         let time = interaction.options.getString("time");
-        time.includes(":") || Number.isInteger(time) ? time = convertHmsToMs(time) : time = ms(time);
+        /^[0-9 :.-]+$/.test(time) ? time = convertHmsToMs(time) : time = ms(time);
         const position = player.position;
         const duration = player.queue.current.duration;
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1,5 +1,5 @@
 module.exports = {
-  
+
   convertTime: function(duration) {
 
     var milliseconds = parseInt((duration % 1000) / 100),
@@ -57,7 +57,7 @@ module.exports = {
   },
 
   convertHmsToMs: function(hms) {
-    var p = hms.split(':'),
+    var p = hms.trim().replace(/[. -]/g,':').split(':'),  // allow dots '.', spaces ' ' and hyphens '-' the same way as colons ':'
         s = 0, m = 1;
 
     while (p.length > 0) {


### PR DESCRIPTION
On request by @PandaIN95 
Now it is permitted to seek to:
HH:mm:ss
HH mm ss
HH.mm.ss
HH-mm-ss

Or any combination like
HH mm.ss

It is possible to also combine with
`H:m:s` (i.e. time without leading zeros = 0:05:03 or 0:5:3)