### PR TITLE
Fix Args setPrefix

### DIFF
--- a/src/commands/Config/setprefix.js
+++ b/src/commands/Config/setprefix.js
@@ -12,43 +12,42 @@ module.exports = {
   execute: async (message, args, client, prefix) => {
 
     const data = await db.findOne({ Guild: message.guildId });
-    const pre = await args.join(" ")
-    if (!pre[0]) {
+    if (!args[0]) {
       const embed = new EmbedBuilder()
         .setDescription("Please provide the new prefix to set!")
         .setColor(client.embedColor)
       return message.reply({ embeds: [embed] });
     }
-    if (pre[1]) {
+    if (args[1]) {
       const embed = new EmbedBuilder()
         .setDescription("You can't set a prefix with a double argument!")
         .setColor(client.embedColor)
       return message.reply({ embeds: [embed] });
     }
-    if (pre[0].length > 3) {
+    if (args[0].length > 2) {
       const embed = new EmbedBuilder()
-        .setDescription("You can't set a prefix with more than 3 characters!")
+        .setDescription("You can't set a prefix with more than 2 characters!")
         .setColor(client.embedColor)
       return message.reply({ embeds: [embed] });
     }
     if (data) {
       data.oldPrefix = prefix;
-      data.Prefix = pre;
+      data.Prefix = args;
       await data.save()
       const update = new EmbedBuilder()
-        .setDescription(`Your prefix is being updated to **${pre}**`)
+        .setDescription(`Your prefix is being updated to **${args}**`)
         .setColor(client.embedColor)
         .setTimestamp()
       return message.reply({ embeds: [update] });
     } else {
       const newData = new db({
         Guild: message.guildId,
-        Prefix: pre,
+        Prefix: args,
         oldPrefix: prefix
       });
       await newData.save()
       const embed = new EmbedBuilder()
-        .setDescription(`The prefix has been successfully updated to **${pre}**`)
+        .setDescription(`The prefix has been successfully updated to **${args}**`)
         .setColor(client.embedColor)
         .setTimestamp()
       return message.reply({ embeds: [embed] });


### PR DESCRIPTION
This is my first change in this project, please understand because I am not an outstanding programmer. The change is that I changed pre to args without a **.join (" ")** which made it always display You can't set a prefix with a double argument!

Now the effect is as follows:
**![Screenshot_1](https://user-images.githubusercontent.com/809818/196442699-06f33c2a-b09d-46a1-9da3-485982890a0b.png)**

Unfortunately, I don't know how to do the same with slashCommand setPrefix