### PR TITLE
Fix a bug with the stop command and prefix

### DIFF
--- a/src/commands/Music/stop.js
+++ b/src/commands/Music/stop.js
@@ -27,7 +27,11 @@ module.exports = {
       player.set("autoplay", false);
     }
 
-    player.destroy();
+    if (!player.twentyFourSeven) {
+        await player.destroy();
+    } else {
+        await player.stop();
+    }
 
     const emojistop = client.emoji.stop;
 

--- a/src/slashCommands/Music/stop.js
+++ b/src/slashCommands/Music/stop.js
@@ -33,7 +33,11 @@ module.exports = {
       player.set("autoplay", false);
     }
 
-    player.destroy();
+    if (!player.twentyFourSeven) {
+        await player.destroy();
+    } else {
+        await player.stop();
+    }
 
     const emojistop = client.emoji.stop;
 


### PR DESCRIPTION
When set to 24/7, then it should just stop the song instead of destroying the player. It also fixed the double reconnection text.