### PR TITLE
Deezer: Support 'deezer.page.link'

### DIFF
--- a/src/events/Client/interactionCreate.js
+++ b/src/events/Client/interactionCreate.js
@@ -51,18 +51,19 @@ module.exports = {
                 focused.value.match(
                   /(?:https:\/\/open\.spotify\.com\/|spotify:)(?:.+)?(track|playlist|artist|episode|show|album)[\/:]([A-Za-z0-9]+)/ ||
                     /^(?:https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?(track|album|playlist)\/(\d+)/ ||
+                    /^((?:https?:)\/\/)?((?:deezer)\.)?((?:page.link))\/([a-zA-Z0-9]+)/ ||
                     /(?:https:\/\/music\.apple\.com\/)(?:\w{2}\/)?(track|album|playlist)/g ||
                     /(http(s|):\/\/music\.apple\.com\/..\/.....\/.*\/([0-9]){1,})\?i=([0-9]){1,}/gim ||
                     /(?:https?:\/\/)?(?:www.|web.|m.)?(facebook|fb).(com|watch)\/(?:video.php\?v=\d+|(\S+)|photo.php\?v=\d+|\?v=\d+)|\S+\/videos\/((\S+)\/(\d+)|(\d+))\/?/g
                 )
               ) {
-                await interaction.respond(
-                  sliced.map((track) => ({
-                    name: track.title,
-                    value: focused.value,
-                  }))
-                );
-                return;
+                  await interaction.respond(
+                    sliced.map((track) => ({
+                      name: track.title,
+                      value: focused.value,
+                    }))
+                  );
+                  return;
               } else {
                 await interaction.respond(
                   sliced.map((track) => ({

--- a/src/structures/Lavamusic.js
+++ b/src/structures/Lavamusic.js
@@ -1,6 +1,7 @@
 const { Message, Client } = require("discord.js");
 const { Structure, Manager } = require("erela.js");
 const { nodes, SpotifyID, SpotifySecret, SearchPlatform } = require("../config");
+const { Preprocess } = require("../utils/UriResolveHelper.js");
 const deezer = require("erela.js-deezer");
 const Spotify = require("erela.js-spotify");
 const apple = require("erela.js-apple");
@@ -46,6 +47,11 @@ Structure.extend(
       }
       getRate() {
         return this.rate;
+      }
+
+      async search(query, requester) {
+        let q = await Preprocess(query);
+        return super.search(q, requester);
       }
 
       set8D(value) {

--- a/src/utils/UriResolveHelper.js
+++ b/src/utils/UriResolveHelper.js
@@ -1,0 +1,19 @@
+const { get } = require("node-superfetch");
+const cheerio = require("cheerio");
+
+const DeezerShareLinkRegex = /^((?:https?:)\/\/)?((?:deezer)\.)?((?:page.link))\/([a-zA-Z0-9]+)/;
+
+module.exports = {    
+
+    Preprocess: async function(url)
+    {
+        if(DeezerShareLinkRegex.test(url)) {
+            const { body } = await get(url);
+            $ = cheerio.load(body);
+            let trackUri = $('meta[property="og:url"]').attr('content');
+            return trackUri;
+        }
+        else return url;
+
+    }
+}


### PR DESCRIPTION
Similarly like YouTube sharing links `youtu.be`, also Deezer's own sharing feature is preferred and practically only way to conveniently obtain link within official mobile application.
As long as Deezer support is declared in LavaMusic readme, all official URIs should be supported by the bot.

This pull request addresses pre-maturily closed issue  #350 [lavamusic/issues/350](https://github.com/brblacky/lavamusic/issues/350)

TBD: Slash command's Interaction.AutoComplete does not work for Deezer after pasting ANY kind of link.