### PR TITLE
Revert "Revert "Add in missing searchOrder configuration option.""

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,8 @@ NODE_SECURE="false" # Lavalink Server SSL Security. If the hostname is an IP add
 # Default: "youtube music"
 #
 # Possibilities:
-#     youtube music - Will prioritize the Music library provided to YouTube by Copyright Holders. Regular YouTube URLs still work in this case. There is cases where https://github.com/brblacky/lavamusic/issues/335 or https://github.com/brblacky/lavamusic/issues/343 can occur when searching. If this occurs, then switch to "youtube" can resolve the issues for you.
+#     youtube music - Will prioritize the Music library provided to YouTube by Copyright Holders. Regular YouTube URLs still work in this case. There is cases where https://github.com/brblacky/lavamusic/issues/335 or https://github.com/brblacky/lavamusic/issues/343 can occur when searching. If this occurs, then switch to "youtube" can resolve these issues for you.
 #     youtube - Will use all of YouTube. Age restricted content will not work unless you have an Email and Password setup for application.yml in the LavaLink Server Configuration.
 #     soundcloud - Will use the SoundCloud library to search for a song. This method can cause some issues as search results can be hit or miss. It is the limitations of SoundCloud API.
 searchPlatform="youtube music" # This option sets the Default Platform that will be used for searching and playing music through the "/play" command or typing a song name in "botname-song-request" channel.
+searchOrder="youtube music,youtube,soundcloud" # Sets the order of Slash command's AutoComplete results. You will need to set a comma after each service or it will cause issues with AutoComplete results. Recommend not touching this setting unless you know what you are doing as misconfiguring this can cause errors to occur in logs.


### PR DESCRIPTION
Reverts brblacky/lavamusic#365

Nothing wrong with the PR as related to https://github.com/brblacky/lavamusic/blob/main/src/config.js#L15 as it was put in correctly as it will look for ``process.env.searchOrder``. It matches up with the rest of config.js and one or the other will need a re-write in any case regardless.