### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
 
   lavamusic:
     container_name: lavamusic
-    image: ghcr.io/brblacky/lavamusic:latest
+    image: ghcr.io/brblacky/lavamusic:main
     environment:
       TOKEN: "put your bot token"
       PREFIX: "your bot prefix"


### PR DESCRIPTION
Fix bad container name on line 58.

If not fixed, this will cause `manifest unknown` errors when running `docker compose up -d` or `docker-compose up -d` command.
Do note, that there are newer versions of docker-compose which ditch usage of `-` hence two different commands provided above.