### PR TITLE
update NodeJS version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 WORKDIR /opt/lavamusic/
 
 # Copy dependencies first to improve layer caching


### PR DESCRIPTION
fix "tsc" not found problem in docker images, by dumping nodejs version used to build docker image to the bot requirements