### PR TITLE
Fix Docker image, again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,40 @@
+# Setup image for building Typescript
 FROM node:18 as builder
 
-# Create app directory
+# Set Work Directory
 WORKDIR /opt/lavamusic/
 
-# Install app dependencies
+# Install dependencies
 COPY package*.json ./
 
+# Update NPM and Clean Install Packages
+RUN npm install -g npm@latest
 RUN npm ci
 
 COPY . .
 
 RUN npm run build
 
+
+## final image delivery
 FROM node:18-slim
 
+#Tell NodeJS that this will run in prod
 ENV NODE_ENV production
 
-# Create app directory
+# Set Working Directory
 WORKDIR /opt/lavamusic/
 
-# Install app dependencies
+# Install dependencies
 COPY package*.json ./
-
-RUN npm ci --production
-
+# Copy Required Files, compiled js, 
 COPY --from=builder /opt/lavamusic/dist ./dist
-COPY --from=builder /opt/lavamusic/src ./src
+COPY --from=builder /opt/lavamusic/src/utils/LavaLogo.txt ./src/utils/LavaLogo.txt
 COPY --from=builder /opt/lavamusic/prisma ./prisma
 
+## Update NPM, Clean Install Packages, and Generate Prisma Files
+RUN npm install -g npm@latest
+RUN npm ci --omit=dev
 RUN npx prisma generate
 
 CMD [ "node", "dist/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
 FROM node:18
+
+# Set the working directory for the container
 WORKDIR /opt/lavamusic/
 
-# Copy dependencies first to improve layer caching
+# Copy the package.json and package-lock.json files to the container
 COPY package*.json ./
-RUN npm install --production
-RUN npx prisma generate
 
+# Install dependencies
+RUN npm install
+
+# Copy the code to the container
 COPY . .
 
-CMD [ "npm", "start" ]
+# Generate Prisma client
+RUN npx prisma generate
+
+# Compile TypeScript code into JavaScript
+RUN npm run build
+
+# Run CODE
+CMD [ "node", "./dist/index.js" ]


### PR DESCRIPTION
This PR fixes the following
1. added `.dockerignore`
2. Build Typescript before running it
3. fixes typescript not properly installed (removed --prod flag from `npm install`)

this should fix any issue with deploying docker image

Edit: modify Dockerfile to reduce Image size from 1GB to ~400MB
<img width="409" alt="Screenshot 2566-04-28 at 3 04 10 PM" src="https://user-images.githubusercontent.com/49745982/235091617-b26ee482-0786-423a-b113-b9c36e65921b.png">