### PR TITLE
Move logo file load into exception handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ if (!fs.existsSync("./src/utils/LavaLogo.txt")) {
   process.exit(1);
 }
 
-const logFile = fs.readFileSync("./src/utils/LavaLogo.txt", "utf-8");
 try {
+  const logFile = fs.readFileSync("./src/utils/LavaLogo.txt", "utf-8");
   console.log('\x1b[35m%s\x1b[0m', logFile);
 } catch (err) {
   logger.error("[CLIENT] An error has occurred :", err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 const logger = new Logger();
 
 if (!fs.existsSync("./src/utils/LavaLogo.txt")) {
+  logger.error("LavaLogo.txt file is missing", err);
   process.exit(1);
 }
 


### PR DESCRIPTION
This PR moves the logic for loading Lavamusic logo file into the try catch block, this prevents the program from crashing if the file is absent when running from a deployment without the file or if the file has no read permissions. It will report the error appropriately.