### PR TITLE
Fixing inconsistent skip embed and other minor changes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ export default {
     img: process.env.IMG_LINK || 'https://i.imgur.com/ud3EWNh.jpg'
   },
   icons: {
-    youtube: 'https://media.discordapp.net/attachments/963097935820750878/1054328059639111700/3670147.png',
+    youtube: 'https://cdn.discordapp.com/attachments/852316384289619968/1142853793822822551/3670147.png',
     spotify: 'https://media.discordapp.net/attachments/963097935820750878/1054333449252655104/spotify.png',
     soundcloud: 'https://media.discordapp.net/attachments/963097935820750878/1054333449638526986/145809.png',
     applemusic: 'https://media.discordapp.net/attachments/963097935820750878/1054333450368340018/apple-music-icon.png',

--- a/src/events/player/TrackEnd.ts
+++ b/src/events/player/TrackEnd.ts
@@ -11,14 +11,14 @@ export default class TrackEnd extends Event {
   public async run(player: Player, track: Song, dispatcher: Dispatcher): Promise<void> {
     dispatcher.previous = dispatcher.current;
     dispatcher.current = null;
+    const m = await dispatcher.nowPlayingMessage?.fetch().catch(() => { });
     if (dispatcher.loop === 'repeat') dispatcher.queue.unshift(track);
     if (dispatcher.loop === 'queue') dispatcher.queue.push(track);
     await dispatcher.play();
     if (dispatcher.autoplay) {
       await dispatcher.Autoplay(track);
     }
-    const m = await dispatcher.nowPlayingMessage?.fetch().catch(() => {});
-    if (m && m.deletable) m.delete().catch(() => {});
+    if (m && m.deletable) await m.delete().catch(() => { });
   }
 }
 

--- a/src/events/player/TrackStart.ts
+++ b/src/events/player/TrackStart.ts
@@ -189,7 +189,7 @@ export default class TrackStart extends Event {
                     iconURL: interaction.user.avatarURL({}),
                   }),
                 ],
-                components: [buttonBuilder()],
+                components: [],
               });
             break;
           case 'loop':


### PR DESCRIPTION
- [ x ] Fixed sometimes the bot deletes the new message instead of old one when a track is skipped.

- [ x ] Changed YouTube icon to one that have the correct colors (the old one has the colors inverted)

- [ x ] Removed the player buttons from the embed as soon as the user skip a song to prevent spamming the button and creating issues

- [ x ] Added history list attribute to keep track of the last 100 played songs to prevent duplicated songs from playing again

- [ x ] Rewrote Autoplay to have a limited number of retries, avoided recursion to avoid potential stack overflow errors

- [ x ] Auto disconnect the bot and clear the history on pressing the button stop