### PR TITLE
fix docker compose to work out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![Run on Repl.it](https://repl.it/badge/github/brblacky/lavamusic)](https://repl.it/github/brblacky/lavamusic)
 [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/import/github/brblacky/lavamusic)
 
-
 <!-- PROJECT LOGO -->
 <br />
 <p align="center">
@@ -117,7 +116,7 @@ Before starting with the installation, you need to have the following:
 ## 🚀 Installation from source
 
 1. Clone the Lavamusic repository:
-  
+
   ```bash
   git clone https://github.com/brblacky/lavamusic.git
 ```
@@ -137,7 +136,7 @@ npm i
 4. Set up your environment variables:
 
 Create a `.env` file in the root directory of your project with the following variables:
-  
+
   ```bash
 TOKEN="." # Your bot token
 PREFIX="!" # Your prefix
@@ -168,13 +167,13 @@ generator client {
 ```
 
  and then run this command
-  
+
   ```bash
   npx prisma generate
 ```
 
 6. Run the bot:
-  
+
   ```bash
   npm run start or npm start
 ```
@@ -183,13 +182,13 @@ generator client {
 
 Generate an invite link for your bot and invite it to your server using the Discord Developer Portal or using permissions calculator: <https://discordapi.com/permissions.html>
 
-## 🚀 Installation using docker-compose
+## 🚀 Installation using Docker Compose
 
-This section assumes you have docker and docker-compose installed and is running correctly.
+This section assumes you have Docker and Docker Compose installed and running correctly.
 
-Download the [Docker-Compose file](https://raw.githubusercontent.com/brblacky/lavamusic/main/docker-compose.yml) in a seperate folder like lavamusic.
+Download the [docker-compose.yml file](https://raw.githubusercontent.com/brblacky/lavamusic/main/docker-compose.yml) in a seperate folder like lavamusic.
 
-Edit the Docker-Compose file and make sure to edit the following variables:
+Edit docker-compose.yml and make sure to set the following variables:
 
 ```yaml
 TOKEN="." # Your bot token and remember, don't show everyone your bot token
@@ -201,11 +200,10 @@ PRODUCTION="true" # "true" for production
 
 ```
 
-For more information how to fill all the varialabes go to this page.
-You do not need to edit anything like the LAVA_LINK_URL, LAVA_LINK_AUTH, LAVA_LINK_NAME, LAVA_LINK_SECURE, DATABASE_URL, and the ports.
-Unless you know what your doing.
+For more information how to fill all the variables go to this page.
+You do not need to edit anything like the LAVA_LINK_URL, LAVA_LINK_AUTH, LAVA_LINK_NAME, LAVA_LINK_SECURE, DATABASE_URL, and the ports unless you know what you're doing.
 
-After saving your changes you can open a terminal and go to the same location as the docker-compose file. Then type the following:
+After saving your changes you can open a terminal and go to the same location as the docker-compose.yml file. Then run the following:
 
 ```bash
 docker-compose up -d
@@ -262,13 +260,12 @@ Your contribution will be reviewed by the project maintainers, and any necessary
 
 Distributed under the Apache-2.0 license License. See ![LICENSE](https://img.shields.io/github/license/brblacky/lavamusic?style=social) for more information.
 
-
 ## ☕ Donate
+
 Do you like this project? Support it by donating
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H2H7LKT9L)
 [![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.me/sdip521)
-
 
 ## 👥 Contributors
 
@@ -277,7 +274,6 @@ Thanks goes to these wonderful people :
 <a href="https://github.com/brblacky/lavamusic/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=brblacky/lavamusic" />
 </a>
-
 
 [version-shield]: https://img.shields.io/github/package-json/v/brblacky/lavamusic?style=for-the-badge
 [contributors-shield]: https://img.shields.io/github/contributors/brblacky/lavamusic.svg?style=for-the-badge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,46 @@
-version: "3.8"
 services:
   mongodb:
     container_name: lavamusic-mongodb
-    image: mongo:latest
+    # higher versions don't work on Apple Silicon
+    image: "bitnami/mongodb:4.4"
     environment:
-      MONGO_INITDB_ROOT_USERNAME: mongoadmin
-      MONGO_INITDB_ROOT_PASSWORD: mongopassword
+      MONGODB_ADVERTISED_HOSTNAME: 127.0.0.1
+      MONGODB_REPLICA_SET_MODE: primary
+      MONGODB_ROOT_USER: mongoadmin
+      MONGODB_ROOT_PASSWORD: mongopassword
+      MONGODB_REPLICA_SET_KEY: replicasetkey123
     restart: on-failure
     volumes:
       - mongodb_data:/data/db
-
   lavalink:
     container_name: lavamusic-lavalink
-    image: fredboat/lavalink:dev
+    image: ghcr.io/lavalink-devs/lavalink
     environment:
       SERVER_PORT: 2333
       SERVER_ADDRESS: 0.0.0.0
       LAVALINK_SERVER_PASSWORD: "youshallnotpass"
-      LAVALINK_SERVER_SOURCES_YOUTUBE: 'true'
-      LAVALINK_SERVER_SOURCES_BANDCAMP: 'true'
-      LAVALINK_SERVER_SOURCES_SOUNDCLOUD: 'true'
-      LAVALINK_SERVER_SOURCES_TWITCH: 'true'
-      LAVALINK_SERVER_SOURCES_VIMEO: 'true'
-      LAVALINK_SERVER_SOURCES_HTTP: 'true'
-      LAVALINK_SERVER_SOURCES_LOCAL: 'false'
+      LAVALINK_SERVER_SOURCES_YOUTUBE: "true"
+      LAVALINK_SERVER_SOURCES_BANDCAMP: "true"
+      LAVALINK_SERVER_SOURCES_SOUNDCLOUD: "true"
+      LAVALINK_SERVER_SOURCES_TWITCH: "true"
+      LAVALINK_SERVER_SOURCES_VIMEO: "true"
+      LAVALINK_SERVER_SOURCES_HTTP: "true"
+      LAVALINK_SERVER_SOURCES_LOCAL: "false"
       LAVALINK_SERVER_BUFFER_DURATION_MS: 400
       LAVALINK_SERVER_FRAME_BUFFER_DURATIONS_MS: 5000
       LAVALINK_SERVER_TRACK_STRUCK_THRESHOLD_MS: 10000
       LAVALINK_SERVER_YOUTUBE_PLAYLIST_LOAD_LIMIT: 6
       LAVALINK_SERVER_PLAYER_UPDATE_INTERVAL: 5
-      LAVALINK_SERVER_YOUTUBE_SEARCH_ENABLED: 'true'
-      LAVALINK_SERVER_SOUNDCLOUD_SEARCH_ENABLED: 'true'
+      LAVALINK_SERVER_YOUTUBE_SEARCH_ENABLED: "true"
+      LAVALINK_SERVER_SOUNDCLOUD_SEARCH_ENABLED: "true"
       #LAVALINK_SERVER_YOUTUBE_CONFIG_EMAIL:
       #LAVALINK_SERVER_YOUTUBE_CONFIG_PASSWORD:
       LAVALINK_SERVER_SENTRY_DSN: ""
+    volumes:
+      - ./plugins/:/opt/Lavalink/plugins/ # persist plugins between restarts, make sure to set the correct permissions (user: 322, group: 322)
     restart: on-failure
-
   lavamusic:
-    container_name: lavamusic
+    container_name: lavamusic-lavalink
     image: ghcr.io/brblacky/lavamusic:main
     environment:
       TOKEN: "your bot token" # Your bot token
@@ -45,12 +48,12 @@ services:
       OWNER_IDS: "your id" # Your id
       CLIENT_ID: "your bot id" # Your bot id
       GUILD_ID: "" # Your server Id if you want to use the for single server
-      PRODUCTION: "true" # true for production 
+      PRODUCTION: "true" # true for production
       SEARCH_ENGINE: "ytsearch" # ytsearch, scsearch or ytmsearch
       MAX_PLAYLIST_SIZE: "100" # Max playlist size
       MAX_QUEUE_SIZE: "100" # Max queue size
-      DATABASE_URL: "mongodb://mongoadmin:mongopassword@db:27017/lavamusic" # Your mongodb url
-      LAVALINK_URL: "localhost:2333" # Your lavalink url
+      DATABASE_URL: "mongodb://mongoadmin:mongopassword@mongodb/lavamusic?authSource=admin&directConnection=true" # Your mongodb url
+      LAVALINK_URL: "lavalink:2333" # Your lavalink url
       LAVALINK_AUTH: "youshallnotpass" # Your lavalink password
       LAVALINK_NAME: "Blacky" # Your lavalink name
       LAVALINK_SECURE: "false" # true if you are using https
@@ -58,14 +61,5 @@ services:
     depends_on:
       - lavalink
       - mongodb
-    links:
-      - mongodb:db
-      - lavalink
-
 volumes:
   mongodb_data:
-
-
-networks:
-  default:
-    name: net-lavamusic


### PR DESCRIPTION
There were a lot of issues with the existing Docker Compose file:

* The mongodb URL was incorrect
* mongodb was not running in replica mode, so Prisma was throwing errors because it could not use transactions
* The compose file was not using the official lavalink Docker image

With these changes, the Docker Compose file works as expected, and you can run `docker compose up -d` to start the Discord bot.