### PR TITLE
fix Docker image not starting up properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ ENV NODE_ENV production
 
 WORKDIR /opt/lavamusic/
 
+# Copy compiled code
+COPY --from=builder /opt/lavamusic/dist ./dist
+COPY --from=builder /opt/lavamusic/src/utils/LavaLogo.txt ./src/utils/LavaLogo.txt
+COPY --from=builder /opt/lavamusic/prisma ./prisma
+
 # Copy package files and install dependencies
 COPY package*.json ./
 RUN apt-get update && \
@@ -32,10 +37,5 @@ RUN apt-get update && \
     npm install --only=production
 
 RUN npx prisma generate
-
-# Copy compiled code
-COPY --from=builder /opt/lavamusic/dist ./dist
-COPY --from=builder /opt/lavamusic/src/utils/LavaLogo.txt ./src/utils/LavaLogo.txt
-COPY --from=builder /opt/lavamusic/prisma ./prisma
 
 CMD [ "node", "dist/index.js" ]


### PR DESCRIPTION
fix docker image not starting up properly due to prisma errors

this pull request does
move the prisma generate command to after the built js file was coppied from the builder container
allowing the prisma generate command to do it's thing and allow the bot to start up properly