### PR TITLE
skip: Stop player when only current track remains

### DIFF
--- a/src/commands/music/Skip.ts
+++ b/src/commands/music/Skip.ts
@@ -43,7 +43,8 @@ export default class Skip extends Command {
 				ctx.locale("event.message.no_music_playing"),
 			);
 		const autoplay = player.get<boolean>("autoplay");
-		if (!autoplay && player.queue.tracks.length === 0) {
+		const currentTrack = player.queue.current;
+		if (!currentTrack && player.queue.tracks.length === 0) {
 			return await ctx.sendMessage({
 				embeds: [
 					embed
@@ -52,15 +53,18 @@ export default class Skip extends Command {
 				],
 			});
 		}
-		const currentTrack = player.queue.current?.info;
-		player.skip(0, !autoplay);
+		if (player.queue.tracks.length === 0 && !autoplay) {
+			await player.stopPlaying(false, false);
+		} else {
+			await player.skip();
+		}
 		if (ctx.isInteraction) {
 			return await ctx.sendMessage({
 				embeds: [
 					embed.setColor(this.client.color.main).setDescription(
 						ctx.locale("cmd.skip.messages.skipped", {
-							title: currentTrack?.title,
-							uri: currentTrack?.uri,
+							title: currentTrack?.info.title,
+							uri: currentTrack?.info.uri,
 						}),
 					),
 				],


### PR DESCRIPTION
This pull request refactors the logic for skipping tracks in the `Skip` music command to handle cases where there is no current track more robustly and to improve the control flow for stopping or skipping playback. The changes ensure that the command behaves correctly when the queue is empty and autoplay is disabled.
