### PR TITLE
docker: dynamically set prisma schema

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,25 @@
 #!/bin/sh
 set -e
 
+# Auto-select Prisma schema based on DATABASE_URL prefix
+if [ -n "$DATABASE_URL" ]; then
+    case "$DATABASE_URL" in
+        postgresql://*|postgres://*)
+            echo "Detected PostgreSQL database, copying PostgreSQL schema..."
+            cp prisma/example.postgresql.schema.prisma prisma/schema.prisma
+            ;;
+        mongodb://*|mongodb+srv://*)
+            echo "Detected MongoDB database, copying MongoDB schema..."
+            cp prisma/example.mongodb.schema.prisma prisma/schema.prisma
+            ;;
+        *)
+            echo "Unknown DATABASE_URL prefix, using default SQLite schema..."
+            ;;
+    esac
+else
+    echo "DATABASE_URL not set, using default SQLite schema..."
+fi
+
 # Generate Prisma client
 npx prisma generate
 


### PR DESCRIPTION
update the `docker-entrypoint.sh` script to automatically select the appropriate Prisma schema file based on the type of database specified in the `DATABASE_URL` environment variable. This enhancement streamlines the setup process for different database backends and reduces manual configuration.