### PR TITLE
Use `UPSERT` instead of `CREATE` for creating guild records

### DIFF
--- a/src/database/server.ts
+++ b/src/database/server.ts
@@ -10,31 +10,31 @@ import {
 import { env } from "../env";
 
 export default class ServerData {
-  private static prisma = new PrismaClient();
-  private prisma: PrismaClient;
+	private static prisma = new PrismaClient();
+	private prisma: PrismaClient;
 
-  constructor() {
-    // reuse the singleton
-    this.prisma = ServerData.prisma;
-  }
+	constructor() {
+		// reuse the singleton
+		this.prisma = ServerData.prisma;
+	}
 
-  public async get(guildId: string): Promise<Guild> {
-    return (
-      (await this.prisma.guild.findUnique({ where: { guildId } })) ??
-      this.createGuild(guildId)
-    );
-  }
+	public async get(guildId: string): Promise<Guild> {
+		return (
+			(await this.prisma.guild.findUnique({ where: { guildId } })) ??
+			this.createGuild(guildId)
+		);
+	}
 
-  private async createGuild(guildId: string): Promise<Guild> {
-    return await this.prisma.guild.upsert({
-      where: { guildId },
-      update: {},
-      create: {
-        guildId,
-        prefix: env.PREFIX,
-      },
-    });
-  }
+	private async createGuild(guildId: string): Promise<Guild> {
+		return await this.prisma.guild.upsert({
+			where: { guildId },
+			update: {},
+			create: {
+				guildId,
+				prefix: env.PREFIX,
+			},
+		});
+	}
 
 	public async setPrefix(guildId: string, prefix: string): Promise<void> {
 		await this.prisma.guild.upsert({


### PR DESCRIPTION
Use `UPSERT` in server entry creation instead of `CREATE`, fixing a race condition where the bot fails to initialize in a server due to unique constraints by making the creation call only create the new entry if it never existed