### PR TITLE
fix:cmd logging not work without avatar

### DIFF
--- a/src/events/client/MessageCreate.ts
+++ b/src/events/client/MessageCreate.ts
@@ -308,7 +308,7 @@ export default class MessageCreate extends Event {
 				const embed = new EmbedBuilder()
 					.setAuthor({
 						name: "Prefix - Command Logs",
-						iconURL: this.client.user?.avatarURL({ size: 2048 }) ?? "",
+						iconURL: this.client.user?.avatarURL({ size: 2048 }) ?? undefined,
 					})
 					.setColor(this.client.config.color.green)
 					.addFields(


### PR DESCRIPTION
# Lavamusic Pull Request

## Description
Fixes an error that occurs when logging to command channel without avatar.

## Related Issue
#850 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Cleanup
- [ ] Documentation update

## Changes Made
- Changed the command log embed's `iconURL` fallback from an empty string to `undefined`.

## Testing
Verified that the embed is created successfully without throwing an error.

## Screenshots / Logs (if applicable)

---

### Checklist
- [x] Code compiles without warnings
- [x] Formatted with `pnpm format`
- [ ] Added/updated documentation
- [x] No breaking changes (or documented if there are)

---

Thank you for contributing to Lavamusic!