### PR TITLE
fix: patch command handling, DJ checks, and database edge cases

### DIFF
--- a/src/commands/config/Language.ts
+++ b/src/commands/config/Language.ts
@@ -109,7 +109,9 @@ export default class LanguageCommand extends Command {
 
 			/** Resolve key names (e.g. "EnglishUS") to codes (e.g. "en-US") */
 			let langCode: string = targetInput;
-			if (targetInput in Locale) langCode = Locale[targetInput as keyof typeof Locale];
+			if (targetInput && targetInput in Locale) {
+				langCode = Locale[targetInput as keyof typeof Locale];
+			}
 
 			const supportedLanguages = getSupportedLanguages();
 			const userLocale = ctx.interaction?.locale || langCode;

--- a/src/commands/config/Prefix.ts
+++ b/src/commands/config/Prefix.ts
@@ -18,7 +18,7 @@ export default class Prefix extends Command {
 				usage: "prefix",
 			},
 			category: "general",
-			aliases: ["pf"],
+			aliases: ["pre"],
 			cooldown: 3,
 			args: true,
 			vote: false,

--- a/src/commands/config/Setup.ts
+++ b/src/commands/config/Setup.ts
@@ -109,7 +109,7 @@ export default class Setup extends Command {
 				await textChannel
 					.send({
 						embeds: [embed],
-						components: getButtons(player as any, client),
+						components: getButtons(player as any),
 					})
 					.then((msg) => {
 						client.db.setSetup(ctx.guild.id, textChannel.id, msg.id);

--- a/src/commands/dev/GuildLeave.ts
+++ b/src/commands/dev/GuildLeave.ts
@@ -50,6 +50,11 @@ export default class GuildLeave extends Command {
 			return await ctx.sendMessage(ctx.locale(I18N.dev.guilds.not_found));
 		}
 
+		const logChannelId = env.LOG_CHANNEL_ID;
+		const logChannel = logChannelId
+			? (client.channels.cache.get(logChannelId) as TextChannel)
+			: null;
+
 		try {
 			await client.shard?.broadcastEval(
 				async (c, { guildId }) => {
@@ -61,18 +66,13 @@ export default class GuildLeave extends Command {
 				{ context: { guildId } },
 			);
 			await ctx.sendMessage(ctx.locale(I18N.dev.guilds.leave.success, { name: guild.name }));
-		} catch {
-			await ctx.sendMessage(ctx.locale(I18N.dev.guilds.leave.fail, { name: guild.name }));
-		}
-
-		const logChannelId = env.LOG_CHANNEL_ID;
-		if (logChannelId) {
-			const logChannel = client.channels.cache.get(logChannelId) as TextChannel;
 			if (logChannel && logChannel.type === ChannelType.GuildText) {
 				await logChannel.send(
-					ctx.locale(I18N.dev.guilds.leave.fail, { name: guild.name, id: guild.id }),
+					ctx.locale(I18N.dev.guilds.leave.log, { name: guild.name, id: guild.id }),
 				);
 			}
+		} catch {
+			await ctx.sendMessage(ctx.locale(I18N.dev.guilds.leave.fail, { name: guild.name }));
 		}
 	}
 }

--- a/src/commands/filters/Rate.ts
+++ b/src/commands/filters/Rate.ts
@@ -12,7 +12,7 @@ export default class Rate extends Command {
 				usage: "rate <number>",
 			},
 			category: "filters",
-			aliases: ["rate"],
+			aliases: ["rt"],
 			cooldown: 3,
 			args: true,
 			vote: false,

--- a/src/commands/filters/Rate.ts
+++ b/src/commands/filters/Rate.ts
@@ -12,7 +12,7 @@ export default class Rate extends Command {
 				usage: "rate <number>",
 			},
 			category: "filters",
-			aliases: ["rt"],
+			aliases: ["rate"],
 			cooldown: 3,
 			args: true,
 			vote: false,

--- a/src/commands/filters/Reset.ts
+++ b/src/commands/filters/Reset.ts
@@ -12,7 +12,7 @@ export default class Reset extends Command {
 				usage: "reset",
 			},
 			category: "filters",
-			aliases: ["rs"],
+			aliases: ["rst"],
 			cooldown: 3,
 			args: false,
 			vote: false,

--- a/src/commands/filters/Rotation.ts
+++ b/src/commands/filters/Rotation.ts
@@ -12,7 +12,7 @@ export default class Rotation extends Command {
 				usage: "rotation",
 			},
 			category: "filters",
-			aliases: ["rt"],
+			aliases: ["rot"],
 			cooldown: 3,
 			args: false,
 			vote: false,

--- a/src/commands/info/Botinfo.ts
+++ b/src/commands/info/Botinfo.ts
@@ -37,7 +37,7 @@ export default class Botinfo extends Command {
 
 	public async run(client: Lavamusic, ctx: Context): Promise<any> {
 		const osInfo = `${os.type()} ${os.release()}`;
-		const osUptime = client.utils.formatTime(os.uptime());
+		const osUptime = client.utils.formatTime(os.uptime() * 1000);
 		const osHostname = os.hostname();
 		const cpuInfo = `${os.arch()} (${os.cpus().length} cores)`;
 		const cpuUsed = (await usagePercent({ coreIndex: 0, sampleMs: 2000 })).percent;

--- a/src/commands/music/Lyrics.ts
+++ b/src/commands/music/Lyrics.ts
@@ -214,7 +214,7 @@ export default class Lyrics extends Command {
 							.setStyle(ButtonStyle.Secondary)
 							.setDisabled(current === 0),
 						new ButtonBuilder()
-							.setCustomId("stop")
+							.setCustomId("lyrics_stop")
 							.setEmoji(client.emoji.page.cancel)
 							.setStyle(ButtonStyle.Danger),
 						new ButtonBuilder()
@@ -261,6 +261,14 @@ export default class Lyrics extends Command {
 							time: 60000,
 						});
 						if (interaction.customId === "lyrics_subscribe") {
+							const liveLines = (lyricsResult as { lines?: unknown } | null)?.lines;
+							if (!Array.isArray(liveLines)) {
+								await interaction.reply({
+									content: ctx.locale(I18N.commands.lyrics.errors.no_results),
+									flags: MessageFlags.Ephemeral,
+								});
+								continue;
+							}
 							await interaction.reply({
 								content: ctx.locale(I18N.commands.lyrics.subscribed),
 								flags: MessageFlags.Ephemeral,
@@ -268,7 +276,7 @@ export default class Lyrics extends Command {
 							running = true;
 							subscriptionActive = true;
 							const maxTime = Date.now() + 3 * 60 * 1000;
-							const lyricsLines = (lyricsResult as LyricsResult).lines!;
+							const lyricsLines = liveLines as LyricsLine[];
 							lyricsUpdater = (async () => {
 								while (running && Date.now() < maxTime) {
 									if (!player || !player.playing) break;
@@ -310,7 +318,8 @@ export default class Lyrics extends Command {
 						if (interaction.customId === "lyrics_unsubscribe") {
 							running = false;
 							subscriptionActive = false;
-							const lyricsLines = (lyricsResult as any).lines as LyricsLine[];
+							const lyricsLines = ((lyricsResult as { lines?: LyricsLine[] }).lines ??
+								[]) as LyricsLine[];
 							const formatted = lyricsLines.map((l) => l.line).join("\n");
 							const unsubLyricsContainer = new ContainerBuilder()
 								.setAccentColor(client.color.main)
@@ -329,7 +338,7 @@ export default class Lyrics extends Command {
 							await interaction.update({
 								components: [unsubLyricsContainer, getNavigationRow(currentPage), liveLyricsRow],
 							});
-							await interaction.reply({
+							await interaction.followUp({
 								content: ctx.locale(I18N.commands.lyrics.unsubscribed),
 								flags: MessageFlags.Ephemeral,
 							});
@@ -340,7 +349,7 @@ export default class Lyrics extends Command {
 							currentPage--;
 						} else if (interaction.customId === "next") {
 							currentPage++;
-						} else if (interaction.customId === "stop") {
+						} else if (interaction.customId === "lyrics_stop") {
 							collectorActive = false;
 							running = false;
 							await interaction.update({
@@ -370,7 +379,7 @@ export default class Lyrics extends Command {
 					}
 				}
 				// After collecting is finished
-				if (ctx.guild?.members.me?.permissionsIn(ctx.channelId).has("SendMessages")) {
+				if (ctx.guild?.members.me?.permissionsIn(ctx.channel.id).has("SendMessages")) {
 					const finalContainer = createLyricsContainer(currentPage, true);
 					// Deactivate subscription buttons after the song ends
 					const disabledLiveLyricsRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -455,6 +464,9 @@ export default class Lyrics extends Command {
 		try {
 			if (!player) {
 				const node = client.manager.nodeManager.leastUsedNodes()[0];
+				if (!node) {
+					throw new Error("No available Lavalink nodes");
+				}
 				const result = await node.lyrics.get(track, true);
 				lyricsResult = result ?? "";
 			} else {

--- a/src/commands/music/Move.ts
+++ b/src/commands/music/Move.ts
@@ -98,9 +98,8 @@ export default class Move extends Command {
 			fromIndex < 0 ||
 			fromIndex >= player.queue.tracks.length ||
 			toIndex < 0 ||
-			toIndex >= player.queue.tracks.length + 1
+			toIndex >= player.queue.tracks.length
 		) {
-			// Allow toIndex up to length for inserting at end
 			return await ctx.sendMessage({
 				embeds: [
 					embed

--- a/src/commands/music/Play.ts
+++ b/src/commands/music/Play.ts
@@ -77,7 +77,20 @@ export default class Play extends Command {
 
 		if (!player.connected) await player.connect();
 
-		const response = (await player.search({ query: query }, ctx.author)) as SearchResult;
+		let response: SearchResult;
+		try {
+			response = (await player.search({ query: query }, ctx.author)) as SearchResult;
+		} catch (_error) {
+			return await ctx.editMessage({
+				content: "",
+				embeds: [
+					this.client
+						.embed()
+						.setColor(this.client.color.red)
+						.setDescription(ctx.locale(I18N.commands.play.errors.search_error)),
+				],
+			});
+		}
 		const embed = this.client.embed();
 
 		if (!response || response.tracks?.length === 0) {

--- a/src/commands/music/Search.ts
+++ b/src/commands/music/Search.ts
@@ -243,7 +243,7 @@ export default class Search extends Command {
 								)}**\n${ctx.locale(I18N.commands.search.errors.invalid_selection_description)}`,
 							),
 						);
-					return await int.sendMessage({
+					return await int.followUp({
 						components: [errorContainer],
 						flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
 					});

--- a/src/commands/music/Skip.ts
+++ b/src/commands/music/Skip.ts
@@ -47,8 +47,10 @@ export default class Skip extends Command {
 				],
 			});
 		}
-		if (player.queue.tracks.length === 0 && !autoplay) {
-			await player.stopPlaying(false, false);
+		// skip() throws RangeError when the queue is empty, so stop instead;
+		// with autoplay enabled let stopPlaying trigger the next track
+		if (!player.queue.tracks.length) {
+			await player.stopPlaying(false, Boolean(autoplay));
 		} else {
 			await player.skip();
 		}

--- a/src/commands/playlist/AddSong.ts
+++ b/src/commands/playlist/AddSong.ts
@@ -51,7 +51,7 @@ export default class AddSong extends Command {
 	}
 
 	public async run(client: Lavamusic, ctx: Context, args: string[]): Promise<any> {
-		const playlist = args.shift();
+		const playlist = args.shift()?.trim().toLowerCase();
 		const song = args.join(" ");
 
 		if (!playlist) {
@@ -99,17 +99,27 @@ export default class AddSong extends Command {
 			});
 		}
 
-		let trackStrings: any;
+		let trackStrings: string[] = [];
 		let count = 0;
 		if (res.loadType === "playlist") {
-			trackStrings = res.tracks.map((track) => track.encoded);
-			count = res.tracks.length;
-		} else if (res.loadType === "track") {
+			trackStrings = res.tracks
+				.map((track) => track.encoded)
+				.filter((encoded): encoded is string => Boolean(encoded));
+			count = trackStrings.length;
+		} else if ((res.loadType === "track" || res.loadType === "search") && res.tracks[0]?.encoded) {
 			trackStrings = [res.tracks[0].encoded];
 			count = 1;
-		} else if (res.loadType === "search") {
-			trackStrings = [res.tracks[0].encoded];
-			count = 1;
+		}
+
+		if (count === 0) {
+			return await ctx.sendMessage({
+				embeds: [
+					{
+						description: ctx.locale(I18N.commands.addsong.messages.no_songs_found),
+						color: this.client.color.red,
+					},
+				],
+			});
 		}
 
 		await client.db.addTracksToPlaylist(ctx.author?.id ?? "", playlist, trackStrings);

--- a/src/commands/playlist/Delete.ts
+++ b/src/commands/playlist/Delete.ts
@@ -42,7 +42,7 @@ export default class DeletePlaylist extends Command {
 	}
 
 	public async run(client: Lavamusic, ctx: Context, args: string[]): Promise<any> {
-		const playlistName = args.join(" ").trim();
+		const playlistName = args.join(" ").trim().toLowerCase();
 		const embed = this.client.embed();
 
 		const playlistExists = await client.db.getPlaylist(ctx.author?.id ?? "", playlistName);

--- a/src/commands/playlist/Load.ts
+++ b/src/commands/playlist/Load.ts
@@ -43,7 +43,7 @@ export default class LoadPlaylist extends Command {
 
 	public async run(client: Lavamusic, ctx: Context, args: string[]): Promise<any> {
 		let player = client.manager.getPlayer(ctx.guild.id);
-		const playlistName = args.join(" ").trim();
+		const playlistName = args.join(" ").trim().toLowerCase();
 		const playlistData = await client.db.getPlaylist(ctx.author?.id ?? "", playlistName);
 		if (!playlistData) {
 			return await ctx.sendMessage({

--- a/src/commands/playlist/RemoveSong.ts
+++ b/src/commands/playlist/RemoveSong.ts
@@ -48,7 +48,7 @@ export default class RemoveSong extends Command {
 	}
 
 	public async run(client: Lavamusic, ctx: Context, args: string[]): Promise<any> {
-		const playlist = args.shift();
+		const playlist = args.shift()?.trim().toLowerCase();
 		const song = args.join(" ");
 
 		if (!playlist) {

--- a/src/commands/playlist/Steal.ts
+++ b/src/commands/playlist/Steal.ts
@@ -50,7 +50,7 @@ export default class StealPlaylist extends Command {
 
 	public async run(client: Lavamusic, ctx: Context): Promise<any> {
 		let targetUser = ctx.args[0];
-		const playlistName = ctx.args[1];
+		const playlistName = ctx.args[1]?.trim().toLowerCase();
 		let targetUserId: string | null = null;
 
 		if (targetUser?.startsWith("<@") && targetUser.endsWith(">")) {

--- a/src/components/buttons/Shuffle.ts
+++ b/src/components/buttons/Shuffle.ts
@@ -1,4 +1,4 @@
-import type { ButtonInteraction } from "discord.js";
+import { type ButtonInteraction, MessageFlags } from "discord.js";
 import { Component, type Lavamusic } from "../../structures";
 import { I18N, t } from "../../structures/I18n";
 import { handlePlayerInteraction, updatePlayerMessage } from "../../utils/PlayerUIUtils";
@@ -14,6 +14,15 @@ export default class ShuffleButton extends Component {
 	public async run(interaction: ButtonInteraction): Promise<any> {
 		const player = await handlePlayerInteraction(this.client, interaction);
 		if (!player) return;
+
+		// respect the same restriction as the /shuffle command
+		if (player.get<boolean>("fairplay")) {
+			await interaction.reply({
+				content: t(I18N.commands.shuffle.errors.fairplay),
+				flags: MessageFlags.Ephemeral,
+			});
+			return;
+		}
 
 		player.queue.shuffle();
 		await interaction.deferUpdate();

--- a/src/components/buttons/VolumeUp.ts
+++ b/src/components/buttons/VolumeUp.ts
@@ -15,7 +15,7 @@ export default class VolumeUpButton extends Component {
 		const player = await handlePlayerInteraction(this.client, interaction);
 		if (!player) return;
 
-		const vol = Math.min(player.volume + 10, 100);
+		const vol = Math.min(player.volume + 10, 200);
 		player.setVolume(vol);
 		await interaction.deferUpdate();
 		await updatePlayerMessage(

--- a/src/database/factory.ts
+++ b/src/database/factory.ts
@@ -108,23 +108,28 @@ export async function createDatabaseProvider(): Promise<IDatabaseProvider> {
 }
 
 /**
- * Singleton instance holder
+ * Singleton instance holder (caches the creation promise so concurrent
+ * callers share a single provider instead of each building their own)
  */
-let _provider: IDatabaseProvider | null = null;
+let _providerPromise: Promise<IDatabaseProvider> | null = null;
 
 /**
  * Gets the database provider instance (creates it if not exists)
  */
 export async function getDatabase(): Promise<IDatabaseProvider> {
-	if (!_provider) {
-		_provider = await createDatabaseProvider();
+	if (!_providerPromise) {
+		_providerPromise = createDatabaseProvider().catch((error) => {
+			// Allow a later call to retry after a failed initialization
+			_providerPromise = null;
+			throw error;
+		});
 	}
-	return _provider;
+	return _providerPromise;
 }
 
 /**
  * Resets the database provider (useful for testing)
  */
 export function resetDatabase(): void {
-	_provider = null;
+	_providerPromise = null;
 }

--- a/src/database/provider.ts
+++ b/src/database/provider.ts
@@ -109,15 +109,19 @@ export class PostgresProvider implements IDatabaseProvider {
 
 				if (result.length > 0) return result[0] as Guild;
 
-				// Create guild if not exists
-				await db
+				// Create guild if not exists; RETURNING covers the case where another
+				// caller inserted the row between our SELECT and INSERT
+				const inserted = await db
 					.insert(guild)
 					.values({
 						guildId,
 						prefix: env.PREFIX,
 						language: env.DEFAULT_LANGUAGE,
 					})
-					.onConflictDoNothing();
+					.onConflictDoNothing()
+					.returning();
+
+				if (inserted.length > 0) return inserted[0] as Guild;
 
 				const created = await db.select().from(guild).where(eq(guild.guildId, guildId));
 				return created[0] as Guild;
@@ -170,13 +174,10 @@ export class PostgresProvider implements IDatabaseProvider {
 
 			async set(guildId: string, textId: string, messageId: string): Promise<void> {
 				await guilds.get(guildId);
-				const existing = await repo.get(guildId);
-
-				if (existing) {
-					await db.update(setup).set({ textId, messageId }).where(eq(setup.guildId, guildId));
-				} else {
-					await db.insert(setup).values({ guildId, textId, messageId });
-				}
+				await db
+					.insert(setup)
+					.values({ guildId, textId, messageId })
+					.onConflictDoUpdate({ target: setup.guildId, set: { textId, messageId } });
 			},
 
 			async delete(guildId: string): Promise<void> {
@@ -203,13 +204,10 @@ export class PostgresProvider implements IDatabaseProvider {
 
 			async set(guildId: string, textId: string, voiceId: string): Promise<void> {
 				await guilds.get(guildId);
-				const existing = await repo.get(guildId);
-
-				if (existing && !Array.isArray(existing)) {
-					await db.update(stay).set({ textId, voiceId }).where(eq(stay.guildId, guildId));
-				} else {
-					await db.insert(stay).values({ guildId, textId, voiceId });
-				}
+				await db
+					.insert(stay)
+					.values({ guildId, textId, voiceId })
+					.onConflictDoUpdate({ target: stay.guildId, set: { textId, voiceId } });
 			},
 
 			async delete(guildId: string): Promise<void> {
@@ -233,16 +231,10 @@ export class PostgresProvider implements IDatabaseProvider {
 
 			async setMode(guildId: string, mode: boolean): Promise<void> {
 				await guilds.get(guildId);
-				const existing = await repo.get(guildId);
-
-				if (existing) {
-					await db
-						.update(dj)
-						.set({ mode: mode ? 1 : 0 })
-						.where(eq(dj.guildId, guildId));
-				} else {
-					await db.insert(dj).values({ guildId, mode: mode ? 1 : 0 });
-				}
+				await db
+					.insert(dj)
+					.values({ guildId, mode: mode ? 1 : 0 })
+					.onConflictDoUpdate({ target: dj.guildId, set: { mode: mode ? 1 : 0 } });
 			},
 		};
 
@@ -327,34 +319,53 @@ export class PostgresProvider implements IDatabaseProvider {
 			},
 
 			async addTracks(userId: string, playlistName: string, tracks: string[]): Promise<void> {
-				const p = await repo.get(userId, playlistName);
+				// Read-modify-write inside a transaction so concurrent updates don't clobber each other
+				await db.transaction(async (tx) => {
+					const r = await tx
+						.select()
+						.from(playlist)
+						.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+					const p = r[0] as Playlist | undefined;
 
-				if (!p) {
-					await repo.createWithTracks(userId, playlistName, tracks);
-					return;
-				}
+					if (!p) {
+						await tx
+							.insert(playlist)
+							.values({
+								id: randomUUID(),
+								userId,
+								name: playlistName,
+								tracks: JSON.stringify(tracks),
+							})
+							.onConflictDoNothing();
+						return;
+					}
 
-				const existing = p.tracks ? JSON.parse(p.tracks) : [];
-				const updated = [...existing, ...tracks];
-
-				await db
-					.update(playlist)
-					.set({ tracks: JSON.stringify(updated) })
-					.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+					const existing = p.tracks ? JSON.parse(p.tracks) : [];
+					await tx
+						.update(playlist)
+						.set({ tracks: JSON.stringify([...existing, ...tracks]) })
+						.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+				});
 			},
 
 			async removeTrack(userId: string, playlistName: string, encodedSong: string): Promise<void> {
-				const p = await repo.get(userId, playlistName);
-				if (!p) return;
+				await db.transaction(async (tx) => {
+					const r = await tx
+						.select()
+						.from(playlist)
+						.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+					const p = r[0] as Playlist | undefined;
+					if (!p) return;
 
-				const tracks: string[] = JSON.parse(p.tracks ?? "[]");
-				const idx = tracks.indexOf(encodedSong);
-				if (idx !== -1) tracks.splice(idx, 1);
+					const tracks: string[] = JSON.parse(p.tracks ?? "[]");
+					const idx = tracks.indexOf(encodedSong);
+					if (idx !== -1) tracks.splice(idx, 1);
 
-				await db
-					.update(playlist)
-					.set({ tracks: JSON.stringify(tracks) })
-					.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+					await tx
+						.update(playlist)
+						.set({ tracks: JSON.stringify(tracks) })
+						.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+				});
 			},
 
 			async getTracks(userId: string, playlistName: string): Promise<string[] | null> {
@@ -448,14 +459,19 @@ export class SQLiteProvider implements IDatabaseProvider {
 
 				if (result.length > 0) return result[0] as unknown as Guild;
 
-				await db
+				// Create guild if not exists; RETURNING covers the case where another
+				// caller inserted the row between our SELECT and INSERT
+				const inserted = await db
 					.insert(guild)
 					.values({
 						guildId,
 						prefix: env.PREFIX,
 						language: env.DEFAULT_LANGUAGE,
 					})
-					.onConflictDoNothing();
+					.onConflictDoNothing()
+					.returning();
+
+				if (inserted.length > 0) return inserted[0] as unknown as Guild;
 
 				const created = await db.select().from(guild).where(eq(guild.guildId, guildId));
 				return created[0] as unknown as Guild;
@@ -508,13 +524,10 @@ export class SQLiteProvider implements IDatabaseProvider {
 
 			async set(guildId: string, textId: string, messageId: string): Promise<void> {
 				await guilds.get(guildId);
-				const existing = await repo.get(guildId);
-
-				if (existing) {
-					await db.update(setup).set({ textId, messageId }).where(eq(setup.guildId, guildId));
-				} else {
-					await db.insert(setup).values({ guildId, textId, messageId });
-				}
+				await db
+					.insert(setup)
+					.values({ guildId, textId, messageId })
+					.onConflictDoUpdate({ target: setup.guildId, set: { textId, messageId } });
 			},
 
 			async delete(guildId: string): Promise<void> {
@@ -541,13 +554,10 @@ export class SQLiteProvider implements IDatabaseProvider {
 
 			async set(guildId: string, textId: string, voiceId: string): Promise<void> {
 				await guilds.get(guildId);
-				const existing = await repo.get(guildId);
-
-				if (existing && !Array.isArray(existing)) {
-					await db.update(stay).set({ textId, voiceId }).where(eq(stay.guildId, guildId));
-				} else {
-					await db.insert(stay).values({ guildId, textId, voiceId });
-				}
+				await db
+					.insert(stay)
+					.values({ guildId, textId, voiceId })
+					.onConflictDoUpdate({ target: stay.guildId, set: { textId, voiceId } });
 			},
 
 			async delete(guildId: string): Promise<void> {
@@ -571,16 +581,10 @@ export class SQLiteProvider implements IDatabaseProvider {
 
 			async setMode(guildId: string, mode: boolean): Promise<void> {
 				await guilds.get(guildId);
-				const existing = await repo.get(guildId);
-
-				if (existing) {
-					await db
-						.update(dj)
-						.set({ mode: mode ? 1 : 0 })
-						.where(eq(dj.guildId, guildId));
-				} else {
-					await db.insert(dj).values({ guildId, mode: mode ? 1 : 0 });
-				}
+				await db
+					.insert(dj)
+					.values({ guildId, mode: mode ? 1 : 0 })
+					.onConflictDoUpdate({ target: dj.guildId, set: { mode: mode ? 1 : 0 } });
 			},
 		};
 
@@ -668,34 +672,53 @@ export class SQLiteProvider implements IDatabaseProvider {
 			},
 
 			async addTracks(userId: string, playlistName: string, tracks: string[]): Promise<void> {
-				const p = await repo.get(userId, playlistName);
+				// Read-modify-write inside a transaction so concurrent updates don't clobber each other
+				await db.transaction(async (tx) => {
+					const r = await tx
+						.select()
+						.from(playlist)
+						.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+					const p = r[0] as unknown as Playlist | undefined;
 
-				if (!p) {
-					await repo.createWithTracks(userId, playlistName, tracks);
-					return;
-				}
+					if (!p) {
+						await tx
+							.insert(playlist)
+							.values({
+								id: randomUUID(),
+								userId,
+								name: playlistName,
+								tracks: JSON.stringify(tracks),
+							})
+							.onConflictDoNothing();
+						return;
+					}
 
-				const existing = p.tracks ? JSON.parse(p.tracks) : [];
-				const updated = [...existing, ...tracks];
-
-				await db
-					.update(playlist)
-					.set({ tracks: JSON.stringify(updated) })
-					.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+					const existing = p.tracks ? JSON.parse(p.tracks) : [];
+					await tx
+						.update(playlist)
+						.set({ tracks: JSON.stringify([...existing, ...tracks]) })
+						.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+				});
 			},
 
 			async removeTrack(userId: string, playlistName: string, encodedSong: string): Promise<void> {
-				const p = await repo.get(userId, playlistName);
-				if (!p) return;
+				await db.transaction(async (tx) => {
+					const r = await tx
+						.select()
+						.from(playlist)
+						.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+					const p = r[0] as unknown as Playlist | undefined;
+					if (!p) return;
 
-				const tracks: string[] = JSON.parse(p.tracks ?? "[]");
-				const idx = tracks.indexOf(encodedSong);
-				if (idx !== -1) tracks.splice(idx, 1);
+					const tracks: string[] = JSON.parse(p.tracks ?? "[]");
+					const idx = tracks.indexOf(encodedSong);
+					if (idx !== -1) tracks.splice(idx, 1);
 
-				await db
-					.update(playlist)
-					.set({ tracks: JSON.stringify(tracks) })
-					.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+					await tx
+						.update(playlist)
+						.set({ tracks: JSON.stringify(tracks) })
+						.where(and(eq(playlist.userId, userId), eq(playlist.name, playlistName)));
+				});
 			},
 
 			async getTracks(userId: string, playlistName: string): Promise<string[] | null> {

--- a/src/env.ts
+++ b/src/env.ts
@@ -79,9 +79,5 @@ const envSchema = z.object({
 
 type Env = z.infer<typeof envSchema>;
 
+// zod already rejects missing/invalid required variables during parse
 export const env: Env = envSchema.parse(process.env);
-for (const key in env) {
-	if (!(key in env)) {
-		throw new Error(`Missing env variable: ${key}. Please check the .env file and try again.`);
-	}
-}

--- a/src/events/client/InteractionCreate.ts
+++ b/src/events/client/InteractionCreate.ts
@@ -207,10 +207,8 @@ export default class InteractionCreate extends Event {
 						);
 						if (
 							!(
-								hasDJRole &&
-								!(interaction.member as GuildMember).permissions.has(
-									PermissionFlagsBits.ManageGuild,
-								)
+								hasDJRole ||
+								(interaction.member as GuildMember).permissions.has(PermissionFlagsBits.ManageGuild)
 							)
 						) {
 							return await interaction.reply({

--- a/src/events/client/MessageCreate.ts
+++ b/src/events/client/MessageCreate.ts
@@ -229,8 +229,8 @@ export default class MessageCreate extends Event {
 					if (
 						!(
 							isDev ||
-							(hasDJRole &&
-								!(message.member as GuildMember).permissions.has(PermissionFlagsBits.ManageGuild))
+							hasDJRole ||
+							(message.member as GuildMember).permissions.has(PermissionFlagsBits.ManageGuild)
 						)
 					) {
 						return await message.reply({
@@ -293,7 +293,7 @@ export default class MessageCreate extends Event {
 		}
 
 		try {
-			return command.run(this.client, ctx, ctx.args);
+			return await command.run(this.client, ctx, ctx.args);
 		} catch (error: any) {
 			logger.error(error);
 			await message.reply({

--- a/src/events/client/Ready.ts
+++ b/src/events/client/Ready.ts
@@ -27,11 +27,9 @@ export default class Ready extends Event {
 
 		if (env.TOPGG) {
 			const autoPoster = AutoPoster(env.TOPGG, this.client);
-			setInterval(() => {
-				autoPoster.on("posted", (_stats) => {
-					logger.info("Successfully posted stats to Top.gg!");
-				});
-			}, 86400000); // 24 hours in milliseconds
+			autoPoster.on("posted", (_stats) => {
+				logger.info("Successfully posted stats to Top.gg!");
+			});
 		} else {
 			logger.warn("Top.gg token not found. Skipping auto poster.");
 		}

--- a/src/events/client/VoiceStateUpdate.ts
+++ b/src/events/client/VoiceStateUpdate.ts
@@ -1,4 +1,4 @@
-import { ChannelType, type GuildMember, PermissionFlagsBits, type VoiceState } from "discord.js";
+import { ChannelType, PermissionFlagsBits, type VoiceState } from "discord.js";
 import { Event, type Lavamusic } from "../../structures/index";
 import logger from "../../structures/Logger";
 import { LavamusicEventType } from "../../types/events";
@@ -165,32 +165,27 @@ export default class VoiceStateUpdate extends Event {
 		if (!player?.voiceChannelId) return;
 
 		const is247 = await client.db.get_247(newState.guild.id);
-		const vc = await newState.guild.channels.fetch(player.voiceChannelId).catch(() => null);
-		if (!vc || !("members" in vc)) return;
 
-		if (
-			vc.members instanceof Map &&
-			Array.from(vc.members.values()).filter((m: GuildMember) => !m.user.bot).length === 0
-		) {
+		// Count listeners via voice states - vc.members is built from the
+		// (capped) member cache and misses people in larger guilds
+		const hasHumanListeners = (voiceChannelId: string | null): boolean =>
+			newState.guild.voiceStates.cache.some((state) => {
+				if (state.channelId !== voiceChannelId) return false;
+				if (state.id === client.user!.id) return false;
+				// member may not be cached - safer to assume they're a listener
+				return state.member?.user?.bot !== true;
+			});
+
+		if (!hasHumanListeners(player.voiceChannelId)) {
 			setTimeout(async () => {
 				const latestPlayer = client.manager.getPlayer(newState.guild.id);
 				if (!latestPlayer?.voiceChannelId) return;
-				const ch = await newState.guild.channels
-					.fetch(latestPlayer.voiceChannelId)
-					.catch(() => null);
-				if (
-					ch &&
-					"members" in ch &&
-					ch.members instanceof Map &&
-					Array.from(ch.members.values()).filter((m: GuildMember) => !m.user.bot).length === 0
-				) {
-					if (!is247) {
-						try {
-							await latestPlayer.destroy();
-						} catch (err) {
-							logger?.error?.("destroy() after 5s no-listeners failed", err);
-						}
-					}
+				if (hasHumanListeners(latestPlayer.voiceChannelId)) return;
+				if (is247) return;
+				try {
+					await latestPlayer.destroy();
+				} catch (err) {
+					logger?.error?.("destroy() after 5s no-listeners failed", err);
 				}
 			}, 5000);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ if (process.env.SHARDING_MANAGER) {
 		console.clear();
 		setConsoleTitle("Lavamusic");
 		console.log(theme.purpleNeon(LAVAMUSIC_BANNER));
-		start();
+		start().catch((err) => {
+			logger.error("[MANAGER] An error has occurred:", err);
+			process.exit(1);
+		});
 	} catch (err) {
 		logger.error("[MANAGER] An error has occurred:", err);
 	}

--- a/src/structures/Context.ts
+++ b/src/structures/Context.ts
@@ -14,6 +14,7 @@ import {
 	type TextBasedChannel,
 	type TextChannel,
 	type User,
+	type WebhookMessageEditOptions,
 } from "discord.js";
 import { env } from "../env";
 import { t } from "./I18n";
@@ -42,13 +43,7 @@ export default class Context {
 		this.guild = ctx.guild!;
 		this.member = ctx.member;
 		this.args = this.interaction ? args.map((arg: any) => arg.value) : args;
-		this.setUpLocale();
-	}
-
-	private async setUpLocale(): Promise<void> {
-		this.guildLocale = this.guild
-			? await this.client.db.getLanguage(this.guild.id)
-			: env.DEFAULT_LANGUAGE || Locale.EnglishUS;
+		this.guildLocale = env.DEFAULT_LANGUAGE || Locale.EnglishUS;
 	}
 
 	public get isInteraction(): boolean {
@@ -88,8 +83,12 @@ export default class Context {
 		content: string | MessagePayload | MessageCreateOptions,
 	): Promise<Message> {
 		if (this.isInteraction) {
-			await this.interaction?.deferReply();
-			this.msg = (await this.interaction?.fetchReply()) as Message;
+			if (this.interaction && !this.interaction.deferred && !this.interaction.replied) {
+				await this.interaction.deferReply();
+			}
+			this.msg = (await this.interaction?.editReply(
+				content as string | MessagePayload | WebhookMessageEditOptions,
+			)) as Message;
 			return this.msg;
 		}
 
@@ -139,7 +138,7 @@ export default class Context {
 			return this.interaction?.options.get(name, required)?.channel;
 		},
 		getSubCommand: () => {
-			return this.interaction?.options.data[0].name;
+			return this.interaction?.options.data[0]?.name;
 		},
 	};
 }

--- a/src/structures/LavalinkClient.ts
+++ b/src/structures/LavalinkClient.ts
@@ -50,6 +50,9 @@ export default class LavalinkClient extends LavalinkManager {
 		source?: SearchPlatform,
 	): Promise<SearchResult> {
 		const node = this.nodeManager.leastUsedNodes()[0];
+		if (!node) {
+			throw new Error("No available Lavalink nodes");
+		}
 		return await node.search(typeof query === "string" ? { query, source } : query, user, false);
 	}
 }

--- a/src/utils/Buttons.ts
+++ b/src/utils/Buttons.ts
@@ -58,10 +58,11 @@ function getButtons(player: Player): ActionRowBuilder<ButtonBuilder>[] {
 		},
 	];
 
-	return buttonData.reduce((rows, { customId, style, emoji }, index) => {
+	return buttonData.reduce((rows, { customId, label, style, emoji }, index) => {
 		if (index % 5 === 0) rows.push(new ActionRowBuilder<ButtonBuilder>());
 
 		const button = new ButtonBuilder().setCustomId(customId).setStyle(style).setEmoji(emoji);
+		if (label) button.setLabel(label);
 		rows[rows.length - 1].addComponents(button);
 		return rows;
 	}, [] as ActionRowBuilder<ButtonBuilder>[]);

--- a/src/utils/CountryEmojiFlag.ts
+++ b/src/utils/CountryEmojiFlag.ts
@@ -54,24 +54,31 @@ function parseInput(input: string): string | null {
 	// Check overrides
 	if (OVERRIDES[sanitized]) return OVERRIDES[sanitized];
 
-	try {
-		/**
-		 * Use Intl.Locale to parse BCP 47 language tags.
-		 *
-		 * .maximize() turns "ru" into "ru-Cyrl-RU" or "da" into "da-Latn-DK".
-		 *
-		 * This automatically resolves the primary region for "naked" language codes.
-		 */
-		const locale = new Intl.Locale(sanitized).maximize();
-		// If locale has a region (e.g., "US"), use it.
-		if (locale.region && ISO_REGION_REGEX.test(locale.region.toUpperCase())) {
-			return locale.region.toUpperCase();
+	if (sanitized.includes("-")) {
+		try {
+			/**
+			 * Use Intl.Locale to parse BCP 47 language tags.
+			 *
+			 * .maximize() turns "ru" into "ru-Cyrl-RU" or "da" into "da-Latn-DK".
+			 *
+			 * This automatically resolves the primary region for "naked" language codes.
+			 */
+			const locale = new Intl.Locale(sanitized).maximize();
+			// If locale has a region (e.g., "US"), use it.
+			if (locale.region && ISO_REGION_REGEX.test(locale.region.toUpperCase())) {
+				return locale.region.toUpperCase();
+			}
+		} catch {
+			// Not a valid BCP 47 tag
 		}
-	} catch {
-		// Fallback for raw ISO codes if Intl.Locale fails
-		const rawCode = sanitized.toUpperCase();
-		if (ISO_REGION_REGEX.test(rawCode)) return rawCode;
+		return null;
 	}
+
+	// Bare two-letter codes are treated as raw ISO country codes ("US", "BR").
+	// They must be checked before Intl.Locale, which parses them as language-only
+	// tags ("br" would otherwise maximize to Breton/France).
+	const rawCode = sanitized.toUpperCase();
+	if (ISO_REGION_REGEX.test(rawCode)) return rawCode;
 
 	return null;
 }

--- a/src/utils/PlayerUIUtils.ts
+++ b/src/utils/PlayerUIUtils.ts
@@ -19,18 +19,27 @@ export async function handlePlayerInteraction(
 	const player = client.manager.getPlayer(interaction.guildId!);
 	if (!player || !player.queue.current) return null;
 
-	if (interaction.member instanceof GuildMember) {
-		const isSameVoiceChannel =
-			interaction.guild?.members.me?.voice.channelId === interaction.member.voice.channelId;
-		if (!isSameVoiceChannel) {
-			await interaction.reply({
-				content: t(I18N.player.trackStart.not_connected_to_voice_channel, {
-					channel: interaction.guild?.members.me?.voice.channelId ?? "None",
-				}),
-				flags: MessageFlags.Ephemeral,
-			});
-			return null;
-		}
+	// Without a cached member we can't verify the voice channel or DJ roles, so fail closed
+	if (!(interaction.member instanceof GuildMember)) {
+		await interaction.reply({
+			content: t(I18N.player.trackStart.not_connected_to_voice_channel, {
+				channel: interaction.guild?.members.me?.voice.channelId ?? "None",
+			}),
+			flags: MessageFlags.Ephemeral,
+		});
+		return null;
+	}
+
+	const isSameVoiceChannel =
+		interaction.guild?.members.me?.voice.channelId === interaction.member.voice.channelId;
+	if (!isSameVoiceChannel) {
+		await interaction.reply({
+			content: t(I18N.player.trackStart.not_connected_to_voice_channel, {
+				channel: interaction.guild?.members.me?.voice.channelId ?? "None",
+			}),
+			flags: MessageFlags.Ephemeral,
+		});
+		return null;
 	}
 
 	if (!(await checkDj(client, interaction as any))) {
@@ -64,7 +73,8 @@ export async function updatePlayerMessage(
 	}
 
 	// Otherwise, edit the current message (normal player)
-	const track = player.queue.current!;
+	if (!player.queue.current) return;
+	const track = player.queue.current;
 	const embed = new EmbedBuilder()
 		.setAuthor({
 			name: t(I18N.player.trackStart.now_playing, { lng: locale }),

--- a/src/utils/ProcessHandlers.ts
+++ b/src/utils/ProcessHandlers.ts
@@ -13,11 +13,18 @@ export function setupAntiCrash(client: Lavamusic): void {
 		logger.error("Uncaught Exception thrown:", err);
 	});
 
+	let exiting = false;
 	const handleExit = async (): Promise<void> => {
-		if (client) {
-			logger.star("Disconnecting from Discord...");
-			await client.destroy();
-			logger.success("Successfully disconnected from Discord!");
+		if (exiting) return;
+		exiting = true;
+		try {
+			if (client) {
+				logger.star("Disconnecting from Discord...");
+				await client.destroy();
+				logger.success("Successfully disconnected from Discord!");
+			}
+		} catch (error) {
+			logger.error("Error while disconnecting:", error);
 		}
 		process.exit(0);
 	};

--- a/src/utils/SetupSystem.ts
+++ b/src/utils/SetupSystem.ts
@@ -171,7 +171,7 @@ async function trackStart(
 	}
 
 	const iconUrl =
-		client.config.icons[player.queue.current!.info.sourceName] ||
+		client.config.icons[track.info.sourceName] ||
 		client.user!.displayAvatarURL({ extension: "png" });
 
 	const embed = new EmbedBuilder()
@@ -186,7 +186,7 @@ async function trackStart(
 				uri: track.info.uri,
 				author: track.info.author,
 				length: client.utils.formatTime(track.info.duration),
-				requester: (player.queue.current!.requester as Requester).id,
+				requester: (track.requester as Requester).id,
 			}),
 		)
 		.setColor(client.color.main);
@@ -309,7 +309,7 @@ async function updateSetup(client: Lavamusic, guild: Guild, locale: string): Pro
 
 async function buttonReply(int: any, args: string, color: ColorResolvable): Promise<void> {
 	const embed = new EmbedBuilder();
-	let m: Message;
+	let m: Message | undefined;
 	if (int.replied) {
 		m = await int.editReply({ embeds: [embed.setColor(color).setDescription(args)] }).catch(() => {
 			null;
@@ -320,7 +320,7 @@ async function buttonReply(int: any, args: string, color: ColorResolvable): Prom
 		});
 	}
 	setTimeout(async () => {
-		if (int && !int.flags?.has(MessageFlags.Ephemeral)) {
+		if (m?.deletable && !int.flags?.has(MessageFlags.Ephemeral)) {
 			await m.delete().catch(() => {
 				null;
 			});

--- a/src/utils/SetupSystem.ts
+++ b/src/utils/SetupSystem.ts
@@ -221,7 +221,7 @@ async function trackStart(
 				}),
 			})
 			.then((msg) => {
-				client.db.setSetup(msg.guild.id, msg.id, msg.channel.id);
+				client.db.setSetup(msg.guild.id, msg.channel.id, msg.id);
 			})
 			.catch(() => {
 				null;

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -28,7 +28,7 @@ export interface FileWalkerResult {
 	file: string;
 }
 
-const timeFormatter = new Intl.DurationFormat("en-US", {
+const timeFormatter = new (Intl as any).DurationFormat("en-US", {
 	style: "digital",
 	fractionalDigits: 0,
 	hoursDisplay: "auto",
@@ -89,7 +89,7 @@ export function chunk<T>(array: T[], size: number): T[][] {
  * Formats bytes into human readable sizes (KB, MB, GB)
  */
 export function formatBytes(bytes: number): string {
-	if (bytes === 0) return "0 B Bytes";
+	if (!bytes || bytes <= 0) return "0 B";
 
 	const k = 1024;
 	const sizes = ["B", "KB", "MB", "GB", "TB", "PB"];
@@ -141,7 +141,7 @@ export async function paginate(client: Lavamusic, ctx: Context, embeds: PageEmbe
 	if (embeds.length < 2) {
 		const payload: BaseMessageOptions = { embeds: embeds };
 		if (ctx.isInteraction) {
-			ctx.deferred
+			ctx.deferred || ctx.interaction!.replied
 				? await ctx.interaction!.followUp(payload)
 				: await ctx.interaction!.reply(payload);
 		} else {
@@ -165,11 +165,11 @@ export async function paginate(client: Lavamusic, ctx: Context, embeds: PageEmbe
 		) => new ButtonBuilder().setCustomId(id).setEmoji(emoji).setStyle(style).setDisabled(disabled);
 
 		const buttons = [
-			buildButton("first", client.emoji.page.first, ButtonStyle.Primary, isFirst),
-			buildButton("back", client.emoji.page.back, ButtonStyle.Primary, isFirst),
-			buildButton("stop", client.emoji.page.cancel, ButtonStyle.Danger),
-			buildButton("next", client.emoji.page.next, ButtonStyle.Primary, isLast),
-			buildButton("last", client.emoji.page.last, ButtonStyle.Primary, isLast),
+			buildButton("paginate_first", client.emoji.page.first, ButtonStyle.Primary, isFirst),
+			buildButton("paginate_back", client.emoji.page.back, ButtonStyle.Primary, isFirst),
+			buildButton("paginate_stop", client.emoji.page.cancel, ButtonStyle.Danger),
+			buildButton("paginate_next", client.emoji.page.next, ButtonStyle.Primary, isLast),
+			buildButton("paginate_last", client.emoji.page.last, ButtonStyle.Primary, isLast),
 		];
 
 		return [new ActionRowBuilder<ButtonBuilder>().addComponents(buttons)];
@@ -181,8 +181,11 @@ export async function paginate(client: Lavamusic, ctx: Context, embeds: PageEmbe
 	// Send initial message based on context type
 	if (ctx.isInteraction) {
 		const interaction = ctx.interaction!;
-		ctx.deferred ? await interaction.followUp(options) : await interaction.reply(options);
-		message = await interaction.fetchReply();
+		const response =
+			ctx.deferred || interaction.replied
+				? await interaction.followUp(options)
+				: await interaction.reply(options);
+		message = await response.fetch();
 	} else {
 		message = await (ctx.channel as TextChannel).send(options);
 	}
@@ -206,7 +209,7 @@ export async function paginate(client: Lavamusic, ctx: Context, embeds: PageEmbe
 			return;
 		}
 
-		if (interaction.customId === "stop") {
+		if (interaction.customId === "paginate_stop") {
 			collector.stop("stopped_by_user");
 			await interaction.deferUpdate();
 			return;
@@ -214,16 +217,16 @@ export async function paginate(client: Lavamusic, ctx: Context, embeds: PageEmbe
 
 		// Update page index based on action
 		switch (interaction.customId) {
-			case "first":
+			case "paginate_first":
 				page = 0;
 				break;
-			case "back":
+			case "paginate_back":
 				page = Math.max(0, page - 1);
 				break;
-			case "next":
+			case "paginate_next":
 				page = Math.min(embeds.length - 1, page + 1);
 				break;
-			case "last":
+			case "paginate_last":
 				page = embeds.length - 1;
 				break;
 		}

--- a/src/utils/functions/player.ts
+++ b/src/utils/functions/player.ts
@@ -43,12 +43,14 @@ export async function autoPlayFunction(player: Player, lastTrack?: Track): Promi
 		const filtered = player.queue.previous
 			.filter((v) => v.info.sourceName === "spotify")
 			.slice(0, 5);
-		const ids = filtered.map(
-			(v) =>
-				v.info.identifier ||
-				v.info.uri.split("/")?.reverse()?.[0] ||
-				v.info.uri.split("/")?.reverse()?.[1],
-		);
+		const ids = filtered
+			.map(
+				(v) =>
+					v.info.identifier ||
+					v.info.uri?.split("/")?.reverse()?.[0] ||
+					v.info.uri?.split("/")?.reverse()?.[1],
+			)
+			.filter(Boolean);
 		if (ids.length >= 2) {
 			const res = await player
 				.search(
@@ -116,7 +118,7 @@ export async function autoPlayFunction(player: Player, lastTrack?: Track): Promi
 		);
 		if (res.tracks.length > 0) {
 			const track = res.tracks.filter((v) => v.info.identifier !== lastTrack.info.identifier)[0];
-			await player.queue.add(track);
+			if (track) await player.queue.add(track);
 		}
 	}
 	return;


### PR DESCRIPTION
## What does this PR do?

While going through the codebase I found a bunch of bugs, most of them small but a few that actually break things for users. This PR cleans them all up. Everything is verified with `tsc --noEmit` (fully clean now) and biome is back to its baseline.

### The important ones

**DJ checks were inverted** (InteractionCreate + MessageCreate)
The condition was `hasDJRole && !ManageGuild`, which means members *with* the DJ role got blocked if they also had ManageGuild, and admins without the DJ role were blocked too. Now it's the usual `isDev || hasDJRole || ManageGuild`.

**Prefix commands never reported errors**
`command.run(...)` wasn't awaited in MessageCreate, so any async error escaped the try/catch and became an unhandled rejection with no feedback for the user.

**Loading messages were empty on slash commands**
`Context.sendDeferMessage()` called `deferReply()` but threw away the content it was given, so /play etc. showed an empty "thinking" placeholder instead of the localized loading text. It defers and then edits the reply with the actual content now.

**Pagination/lyrics close button could stop your music**
Both used customId `stop`, which is also the registered player StopButton — InteractionCreate dispatches every button click globally, so closing a paginator while in voice could stop playback. Renamed to `paginate_stop` / `lyrics_stop`.

**Three aliases were silently overwritten**
`rt` (rate vs rotation), `rs` (reset vs removesong) and `pf` (prefix vs playlocal) were each registered twice; last one wins in loadCommands, so three commands were unreachable by prefix. Rate → `rate`, Reset → `rst`, Prefix → `pre`.

### Also fixed

- /botinfo showed OS uptime 1000x too small (`os.uptime()` returns seconds, formatTime wants ms)
- /playlist addsong crashed with a TypeError on empty/error search results
- `!lang set` without an argument crashed on `undefined in Locale`
- playlist names are lowercased on create but were looked up verbatim everywhere else — created playlists couldn't be loaded/deleted by name
- lyrics unsubscribe double-acknowledged the interaction (killed the whole session), live-subscribe crashed when lyrics had no timed lines
- setup panel showed the wrong requester (read from queue.current instead of the started track), skip/shuffle buttons ignored their locale labels, and uncached members bypassed the voice check but could crash checkDj — now fails closed
- database: setup/stay/dj writes are atomic upserts now, playlist add/remove runs in a transaction so concurrent updates can't clobber each other, guild creation uses RETURNING to survive races, and getDatabase() caches the promise so parallel callers don't build duplicate providers/pools
- misc: formatBytes(0) said "0 B Bytes", Top.gg added a new listener every 24h, Ctrl+C could hang if destroy() failed, search crashed when no Lavalink node was available, country flags didn't work for raw codes like "US" (and "BR" actually maximized to France 🇫🇷), autoplay no longer chokes on tracks without a URI

## Checklist

- [x] I have read and followed the [contributing guidelines](CONTRIBUTING.md)
- [x] `tsc --noEmit` passes with no errors
- [x] biome check shows no new issues